### PR TITLE
Refactor common code :: 공통코드 도메인 리팩터링

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -28,14 +28,18 @@ dependencies {
     //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.flywaydb:flyway-core'
-    compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    //lombok
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-
 
 }
 

--- a/module-api/src/main/java/com/kernel360/commoncode/controller/CommonCodeController.java
+++ b/module-api/src/main/java/com/kernel360/commoncode/controller/CommonCodeController.java
@@ -14,8 +14,13 @@ import java.util.List;
 @RequestMapping("/commoncode")
 public class CommonCodeController {
 
+    final CommonCodeService commonCodeService;
+
     @Autowired
-    CommonCodeService commonCodeService;
+    public CommonCodeController(CommonCodeService commonCodeService) {
+        this.commonCodeService = commonCodeService;
+    }
+
     @GetMapping("/{codeName}")
     public List<CommonCodeDto> getCommonCode (@PathVariable String codeName){
 

--- a/module-api/src/main/java/com/kernel360/commoncode/service/CommonCodeService.java
+++ b/module-api/src/main/java/com/kernel360/commoncode/service/CommonCodeService.java
@@ -10,14 +10,16 @@ import java.util.List;
 @Service
 public class CommonCodeService {
 
+    final CommonCodeRepository commonCodeRepository;
+
     @Autowired
-    private CommonCodeRepository commonCodeRepository;
+    public CommonCodeService(CommonCodeRepository commonCodeRepository) {
+        this.commonCodeRepository = commonCodeRepository;
+    }
 
     public List<CommonCodeDto> getCodes(String codeName) {
 
-        boolean isUsed = true;
-
-        return commonCodeRepository.findAllByUpperNameAndIsUsed(codeName,isUsed)
+        return commonCodeRepository.findAllByUpperNameAndIsUsed(codeName,true)
                                    .stream()
                                    .map(CommonCodeDto::from)
                                    .toList();

--- a/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerTest.java
@@ -1,5 +1,6 @@
 package com.kernel360.commoncode.controller;
 
+import com.kernel360.commoncode.dto.CommonCodeDto;
 import com.kernel360.commoncode.service.CommonCodeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +15,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @WebMvcTest(CommonCodeController.class)
@@ -36,8 +42,24 @@ class CommonCodeControllerTest {
 
     @Test
     @DisplayName("getCommonCode :: 공통코드 조회 요청")
-    public void 상위코드명을_인수로_받는_공통코드_목록_조회() throws Exception {
+    void 상위코드명을_인수로_받는_공통코드_목록_조회() throws Exception {
+
         String pathVariable = "color";
+        Integer codeNo = 1;
+        String codeName = "테스트용 코드";
+        Integer upperNo = null;
+        String upperName = null;
+        Integer sortOrder = 1;
+        Boolean isUsed = true;
+        String description = "테스트용 코드값";
+        LocalDate createdAt = LocalDate.now();
+        String createdBy = "admin";
+        LocalDate modifiedAt = null;
+        String modifiedBy = null;
+
+        CommonCodeDto item = CommonCodeDto.of(codeNo,codeName,upperNo,upperName,sortOrder,isUsed,description,createdAt,createdBy,modifiedAt,modifiedBy);
+
+        given(commonCodeService.getCodes(pathVariable)).willReturn(Collections.singletonList(item));
 
         mvc.perform(MockMvcRequestBuilders.get("/commoncode/{codeName}", pathVariable))
                .andExpect(MockMvcResultMatchers.status().isOk())

--- a/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDate;
 import java.util.Collections;
-import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/module-api/src/test/java/com/kernel360/commoncode/service/CommonCodeServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/commoncode/service/CommonCodeServiceTest.java
@@ -10,11 +10,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;

--- a/module-api/src/test/java/com/kernel360/commoncode/service/CommonCodeServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/commoncode/service/CommonCodeServiceTest.java
@@ -20,7 +20,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class CommonCodeServiceTest {
+class CommonCodeServiceTest {
     @Mock
     private CommonCodeRepository commonCodeRepository;
 
@@ -35,14 +35,14 @@ public class CommonCodeServiceTest {
 
         List<CommonCode> entities = new ArrayList<>();
 
-        entities.add(new CommonCode (21,"white",20,"color",1,true,"흰색","2023-12-28","admin"));
-        entities.add(new CommonCode (22,"gray",20,"color",5,true,"쥐색","2023-12-28","admin"));
-        entities.add(new CommonCode (23,"black",20,"color",6,true,"검정색","2023-12-28","admin"));
-        entities.add(new CommonCode (24,"red",20,"color",4,true,"빨간색","2023-12-28","admin"));
-        entities.add(new CommonCode (25,"yellow",20,"color",2,true,"노란색","2023-12-28","admin"));
-        entities.add(new CommonCode (26,"green",20,"color",3,true,"초록색","2023-12-28","admin"));
-        entities.add(new CommonCode (27,"blue",20,"color",4,true,"파란색","2023-12-28","admin"));
-        entities.add(new CommonCode (28,"etc",20,"color",7,true,"기타","2023-12-28","admin"));
+        entities.add(CommonCode.builder().codeNo(21).codeName("white").upperNo(20).upperName("color").sortOrder(1).isUsed(true).description("흰색").build());
+        entities.add(CommonCode.builder().codeNo(22).codeName("gray").upperNo(20).upperName("color").sortOrder(5).isUsed(true).description("쥐색").build());
+        entities.add(CommonCode.builder().codeNo(23).codeName("black").upperNo(20).upperName("color").sortOrder(6).isUsed(true).description("검정색").build());
+        entities.add(CommonCode.builder().codeNo(24).codeName("red").upperNo(20).upperName("color").sortOrder(4).isUsed(true).description("빨간색").build());
+        entities.add(CommonCode.builder().codeNo(25).codeName("yellow").upperNo(20).upperName("color").sortOrder(2).isUsed(true).description("노란색").build());
+        entities.add(CommonCode.builder().codeNo(26).codeName("green").upperNo(20).upperName("color").sortOrder(3).isUsed(true).description("초록색").build());
+        entities.add(CommonCode.builder().codeNo(27).codeName("blue").upperNo(20).upperName("color").sortOrder(4).isUsed(true).description("파란색").build());
+        entities.add(CommonCode.builder().codeNo(28).codeName("etc").upperNo(20).upperName("color").sortOrder(7).isUsed(true).description("기타").build());
 
         /** stub **/
         when(commonCodeRepository.findAllByUpperNameAndIsUsed(anyString(),anyBoolean())).thenReturn(entities);

--- a/module-domain/src/main/java/com/kernel360/base/BaseEntity.java
+++ b/module-domain/src/main/java/com/kernel360/base/BaseEntity.java
@@ -1,6 +1,7 @@
 package com.kernel360.base;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -10,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import java.time.LocalDate;
 
 @Getter
+@MappedSuperclass
 public class BaseEntity {
     @Column(name = "created_at", nullable = false)
     @CreatedDate

--- a/module-domain/src/main/java/com/kernel360/commoncode/entity/CommonCode.java
+++ b/module-domain/src/main/java/com/kernel360/commoncode/entity/CommonCode.java
@@ -1,18 +1,20 @@
 package com.kernel360.commoncode.entity;
 
+import com.kernel360.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDate;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @Table(name = "common_code")
-public class CommonCode {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommonCode extends BaseEntity {
     @Id
     @Column(name = "code_no", nullable = false)
     private Integer codeNo;
@@ -35,22 +37,8 @@ public class CommonCode {
     @Column(name = "description", length = Integer.MAX_VALUE)
     private String description;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDate createdAt;
-
-    @Column(name = "created_by", nullable = false, length = Integer.MAX_VALUE)
-    private String createdBy;
-
-    @Column(name = "modified_at")
-    private LocalDate modifiedAt;
-
-    @Column(name = "modified_by", length = Integer.MAX_VALUE)
-    private String modifiedBy;
-
-    public CommonCode(int codeNo, String codeName, int upperNo, String upperName, int sortOrder, boolean isUsed, String description, String createdAt, String createdBy) {
-    }
-
-    public CommonCode() {
+    @Builder
+    public CommonCode (Integer codeNo, String codeName, Integer upperNo, String upperName, Integer sortOrder, Boolean isUsed, String description){
 
     }
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`Feat common code https://github.com/Kernel360/F1-WashPedia-BE/pull/14
PR을 기반으로 리팩터링 작업 수행
<br>

## 🔨 Modified
> BaseEntity :: @MappedSuperclass 애노테이션을 추가했습니다.
이 애노테이션이 없으면 조회시 상속을 받았어도 슈퍼클래스의 값이 조회가 되지 않습니다.
참고 URL :: https://eocoding.tistory.com/60
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/1e428001-dafb-45b4-a8a2-f79c4c501119)

CommonCodeController, CommonCodeService :: 의존성 주입을 스프링 표준 권장 방식으로 변경하였습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/2ee38fa7-dfa9-46cc-9308-6a1a1c0a0313)

CommonCode Entity :: @NoArgsConstructor(access = AccessLevel.PROTECTED) 를 추가하고, 엔티티 클래스 내 변수에 대응하는 생성자 추가 밎 @builder 애노테이션을 추가하였습니다.
참고 URL :: https://velog.io/@wonizizi99/Spring-%EC%98%AC%EB%B0%94%EB%A5%B8-Lombok-%EC%82%AC%EC%9A%A9%EB%B2%95DtotoEntity-Builder
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/24677704-6135-46fb-85f2-72f3b97d8c3c)

CommonCodeServiceTest :: 테스트코드 mock 데이터를 new 생성자에서 builder로 리팩터링 하였습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/5563fa0d-48a8-496a-8ad7-505fda7ebf4e)

CommonCodeControllerTest :: 테스트코드 mock 데이터를 추가하고, 결과시 mock 데이터 확인이 가능하도록 변경하였습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/b14570c8-db70-4969-b7fd-004d19da6c72)
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/3f40bc83-5a1b-4dc9-ab21-7caa5822df95)



<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>

---


### 📋 커밋 전 체크리스트
- [ √ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ √ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes [#](https://github.com/Kernel360/F1-WashPedia-BE/issues/16)
