### PR TITLE
chore :: flyway SQL v.1.0.0 수정

### DIFF
--- a/module-api/src/main/resources/db/migration/V1.0.0__init.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.0__init.sql
@@ -13,6 +13,14 @@ CREATE TABLE if not exists Member
     modified_by VARCHAR
 );
 
+CREATE SEQUENCE if not exists member_member_no_seq
+    INCREMENT BY 50
+    MINVALUE 1
+    MAXVALUE 2147483647
+    START 1
+    CACHE 1
+    NO CYCLE;
+
 CREATE TABLE if not exists Brand
 (
     brand_no    SERIAL PRIMARY KEY,
@@ -24,6 +32,14 @@ CREATE TABLE if not exists Brand
     modified_at DATE,
     modified_by VARCHAR
 );
+
+CREATE SEQUENCE if not exists brand_brand_no_seq
+    INCREMENT BY 50
+    MINVALUE 1
+    MAXVALUE 2147483647
+    START 1
+    CACHE 1
+    NO CYCLE;
 
 CREATE TABLE if not exists Wash_Info
 (
@@ -41,6 +57,14 @@ CREATE TABLE if not exists Wash_Info
     FOREIGN KEY (member_no) REFERENCES Member (member_no)
 );
 
+CREATE SEQUENCE if not exists wash_info_wash_no_seq
+    INCREMENT BY 50
+    MINVALUE 1
+    MAXVALUE 2147483647
+    START 1
+    CACHE 1
+    NO CYCLE;
+
 CREATE TABLE if not exists Car_Info
 (
     car_no      SERIAL PRIMARY KEY,
@@ -56,6 +80,14 @@ CREATE TABLE if not exists Car_Info
     modified_by CHAR,
     FOREIGN KEY (member_no) REFERENCES Member (member_no)
 );
+
+CREATE SEQUENCE if not exists car_info_car_no_seq
+    INCREMENT BY 50
+    MINVALUE 1
+    MAXVALUE 2147483647
+    START 1
+    CACHE 1
+    NO CYCLE;
 
 CREATE TABLE if not exists Product
 (
@@ -73,3 +105,75 @@ CREATE TABLE if not exists Product
     view_count   INT     NOT NULL DEFAULT 0,
     FOREIGN KEY (brand_no) REFERENCES Brand (brand_no)
 );
+
+CREATE SEQUENCE if not exists product_product_no_seq
+    INCREMENT BY 50
+    MINVALUE 1
+    MAXVALUE 2147483647
+    START 1
+    CACHE 1
+    NO CYCLE;
+
+CREATE TABLE if not exists common_code
+(
+    code_no int4 NOT NULL,
+    code_name varchar NOT NULL,
+    upper_no int4 NULL,
+    upper_name varchar NULL,
+    sort_order int4 NOT NULL,
+    is_used bool NOT NULL DEFAULT true,
+    description varchar NULL,
+    created_at date NOT NULL,
+    created_by varchar NOT NULL,
+    modified_at date NULL,
+    modified_by varchar NULL
+);
+
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(1, 'carbrand', 0, '', 1, false, '차량 브랜드', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(2, 'Hyundai', 1, 'carbrand', 1, false, '현대', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(3, 'Kia', 1, 'carbrand', 2, false, '기아', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(4, 'Renault', 1, 'carbrand', 3, false, '르노', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(5, 'KG Mobility', 1, 'carbrand', 4, false, 'KG모빌리티', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(5, 'Chevrolet', 1, 'carbrand', 5, false, '쉐보레', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(6, 'Benz', 1, 'carbrand', 6, false, '벤츠', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(7, 'BMW', 1, 'carbrand', 7, false, '벰베', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(8, 'Audi', 1, 'carbrand', 8, false, '아우디', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(9, 'ETC', 1, 'carbrand', 9, false, '기타', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(10, 'cartype', 0, '', 2, true, '차량 유형', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(11, 'Sedan', 10, 'cartype', 1, true, '세단', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(12, 'Hatchback', 10, 'cartype', 2, true, '해치백', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(13, 'SUV', 10, 'cartype', 3, true, 'SUV', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(14, 'ETC', 10, 'cartype', 4, true, '기타', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(15, 'segment', 0, '', 3, true, '차량 크기', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(16, 'Micro', 15, 'segment', 1, true, '경차', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(17, 'Subcompact', 15, 'segment', 2, true, '소형', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(18, 'Compact', 15, 'segment', 3, true, '중형', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(19, 'Fullsize', 15, 'segment', 4, true, '대형', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(20, 'color', 0, '', 4, true, '차량 색상', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(21, 'white', 20, 'color', 1, true, '흰색', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(22, 'gray', 20, 'color', 5, true, '쥐색', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(23, 'black', 20, 'color', 6, true, '검정색', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(24, 'red', 20, 'color', 4, true, '빨간색', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(25, 'yellow', 20, 'color', 2, true, '노란색', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(26, 'green', 20, 'color', 3, true, '초록색', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(27, 'blue', 20, 'color', 4, true, '파란색', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(28, 'etc', 20, 'color', 7, true, '기타', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(29, 'perl', 0, '', 5, true, '차량 페인트 펄', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(30, 'TRUE', 28, 'perl', 1, true, '있음', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(31, 'FALSE', 28, 'perl', 2, true, '없음', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(32, 'clearcoat', 0, '', 6, true, '차량 페인트 마감', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(33, 'TRUE', 31, 'clearcoat', 1, true, '있음', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(34, 'FALSE', 31, 'clearcoat', 2, true, '없음', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(35, 'driving', 0, '', 7, true, '주행환경', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(36, 'comport', 34, 'driving', 1, true, '도심', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(37, 'highway', 34, 'driving', 2, true, '고속', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(38, 'complex', 34, 'driving', 3, true, '복합', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(39, 'parking', 0, '', 8, true, '주차환경', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(40, 'house', 38, 'parking', 1, true, '실내/지하', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(41, 'road', 38, 'parking', 2, true, '노상', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(42, 'piloti', 38, 'parking', 3, true, '필로티', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(43, 'interest', 0, '', 9, true, '주요관심사', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(44, 'outercare', 42, 'washInfo', 1, true, '도장', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(45, 'tire', 42, 'washInfo', 2, true, '타이어', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(46, 'wheel', 42, 'washInfo', 3, true, '휠', '2023-12-28', 'admin', NULL, NULL);
+INSERT INTO common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(47, 'innercare', 42, 'washInfo', 4, true, '실내', '2023-12-28', 'admin', NULL, NULL);


### PR DESCRIPTION
## 💡 Motivation and Context
          > 추가로 현재 저희가 flyway 적용해서 사용하고 있으니 common_code 테이블에 대한 sql 파일 작성(src/main/resources/db/migration/) 해주시면 저희도 동일 테이블 생성되니 ddl에 대한 sql 파일도 같이 올려주실 수 있을까요?
          
https://github.com/Kernel360/F1-WashPedia-BE/pull/14#issuecomment-1873582047

PR 의견 반영하여 flayway 파일을 업데이트 하였습니다.

깡통 DB 기준 서버 부팅시 동작순서가 flyway -> jpa(hibernate) 이므로
1.0.0을 읽어 테이블이 생성 된 뒤 테이블 별 시퀀스가 추가되어야 하는데
현재 로컬 개발환경에선 이미 각자 개발진행중이고 시퀀스까지 생성된 상황이므로
이러한 개발환경까지 고려해서 스크립트를 다 맞추기 곤란하다 판단되었습니다.
다행이 현재 개발 진행하면서 테이블에 데이터가 적재되지 않았으므로 
1.0.1로 버전업을 취소하고 1.0.0 파일을 수정하는 방향으로 바꾸었습니다.

앞으로 플라이웨이 관련 PR은 파일에 기재된 버전명에 맞춰서 100 101 102 이런식으로 올라가는게
서로 일치해서 보기 좋을 것 같다는 의견 드립니다.

<br>

## 🔨 Modified
> 테이블에 따른 시퀀스 DDL 추가
공통코드 테이블 DDL 추가, 공통코드 데이터 INSERT DML 추가하였습니다.

<br>

## 🌟 More
- _파일 pull 받으신 후 정상동작하시는지 확인 부탁드립니다. (제 로컬에서는 잘 되었음)
- 사전에 로컬 DB에서는 해당하는 값을 삭제하고 수행하셔야 에러가 발생되지 않을 것입니다. 
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/48ced5d0-9898-42d1-833a-63594be6b37a)
- 기존 로컬 환경에서 시퀀스 증감식 50으로 변경이 귀찮으시다면 테이블을 전부 drop 하신 후 실행하시면 자동으로 생성됩니다.

<br>

---


### 📋 커밋 전 체크리스트
- [x] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes  chore, refactor :: flyway SQL v.1.0.0 수정 #15
