### PR TITLE
feat: aop 로깅 및 logback 설정

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -24,23 +24,27 @@ repositories {
 dependencies {
     implementation project(':module-common')
     implementation project(':module-domain')
+
+    // spring-boot-starter
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.flywaydb:flyway-core'
-    runtimeOnly 'org.postgresql:postgresql'
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
-
+    // flyway
+    implementation 'org.flywaydb:flyway-core'
+    // postgresql
+    runtimeOnly 'org.postgresql:postgresql'
     //lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-
 }
 
 tasks.named('test') {

--- a/module-api/src/main/java/com/kernel360/aop/LogAspect.java
+++ b/module-api/src/main/java/com/kernel360/aop/LogAspect.java
@@ -1,0 +1,42 @@
+package com.kernel360.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Slf4j
+@Aspect
+@Component
+public class LogAspect {
+
+    @Pointcut("within(*..*Controller)")
+    public void allController() {}
+
+    @Before("allController()")
+    public void beforeRequest(JoinPoint joinPoint) {
+        log.info("###Start request {}", joinPoint.getSignature().toShortString());
+
+        Arrays.stream(joinPoint.getArgs())
+              .map(arg -> arg != null ? arg : "null")
+              .map(str -> "\t" + str)
+              .forEach(log::info);
+    }
+
+    @AfterReturning(pointcut = "allController()", returning = "returnValue")
+    public void afterReturningLogging(JoinPoint joinPoint, Object returnValue) {
+        log.info("###End request {}", joinPoint.getSignature().toShortString());
+
+        if (returnValue == null) return;
+
+        log.info("###returnValue -> {}", returnValue);
+    }
+
+    @AfterThrowing(pointcut = "allController()", throwing = "e")
+    public void afterThrowingLogging(JoinPoint joinPoint, Exception e) {
+        log.error("###Occured error in request {}", joinPoint.getSignature().toShortString());
+        log.error("###e.getMessage() -> {}", e.getMessage());
+    }
+}

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -15,3 +15,12 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
+
+logging:
+  file:
+    path: ./logs/api/
+    name: api-log
+  logback:
+    rollingpolicy:
+      max-history: 7
+      total-size-cap: 50MB

--- a/module-api/src/main/resources/logback-spring.xml
+++ b/module-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint}
+              %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE}.%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+            <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY}</maxHistory>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP}</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <!--  local 환경  -->
+    <springProfile name="local">
+        <root level="info">
+            <appender-ref ref="STDOUT" />
+            <appender-ref ref="FILE" />
+        </root>
+    </springProfile>
+    <!--  test 환경  -->
+    <springProfile name="test">
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 💡 Motivation and Context
`aop 로깅 및 logback 설정`

<br>

## 🔨 Modified
> 로그 설정, AOP 로깅
  - _로그 설정_
    - 로컬 로그 경로: ./log/api 하위
    - 로컬 로그 레벨: info
    - 로그명: api-log.yyyy-mm-dd-i.log
    - 기타: 최대 7일 보관, 50MB 초과 시 i값 증가 후 파일 추가생성
  - _AOP 로깅_
    - 전체 컨트롤러에 대한 로깅 세팅
    - @ Before, @AfterReturning, @AfterThrowing에 대해 설정

<br>

## 🌟 More
- _로그 외에 AOP 필요한 부분이 있을지 논의 필요할지도 (우선순위는 아니더라도)_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #22 
