### PR TITLE
[feat] aop 로깅, logback → 코드리뷰 반영 수정

### DIFF
--- a/module-api/src/main/java/com/kernel360/aop/LogAspect.java
+++ b/module-api/src/main/java/com/kernel360/aop/LogAspect.java
@@ -20,8 +20,7 @@ public class LogAspect {
         log.info("###Start request {}", joinPoint.getSignature().toShortString());
 
         Arrays.stream(joinPoint.getArgs())
-              .map(arg -> arg != null ? arg : "null")
-              .map(str -> "\t" + str)
+              .map(arg -> arg != null ? "\t" + arg : "\tnull")
               .forEach(log::info);
     }
 

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -22,5 +22,6 @@ logging:
     name: api-log
   logback:
     rollingpolicy:
-      max-history: 7
-      total-size-cap: 50MB
+      max-history: 14
+      max-file-size: 50MB
+      total-size-cap: 5GB

--- a/module-api/src/main/resources/logback-spring.xml
+++ b/module-api/src/main/resources/logback-spring.xml
@@ -18,18 +18,18 @@
         <encoder>
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
             <fileNamePattern>${LOG_PATH}/${LOG_FILE}.%d{yyyy-MM-dd}-%i.log</fileNamePattern>
             <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY}</maxHistory>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP}</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxFileSize>${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE}</maxFileSize>
+            <totalSizeCap>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP}</totalSizeCap>
         </rollingPolicy>
     </appender>
 
     <!--  local 환경  -->
     <springProfile name="local">
-        <root level="info">
+        <root level="trace">
             <appender-ref ref="STDOUT" />
             <appender-ref ref="FILE" />
         </root>


### PR DESCRIPTION
## 💡 Motivation and Context
`aop 로깅, logback → 코드리뷰 반영 수정`

<br>

## 🔨 Modified
> 코드리뷰 반영 수정
  - _로그 설정 변경_
    - 로컬 로그 레벨: trace
    - 로그명: api-log.yyyy-mm-dd-i.log
    - 기타: 최대 14일 보관, 50MB 초과 시 i값 증가 후 파일 추가생성, (+)최대 용량 5GB
  - _AOP 로깅_
    - @ Before 내 코드 일부 수정
  - _logback 파일 수정_
    - 1.1.7 이후 버전인 경우, SizeAndTimeBasedFNATP 사용하지 않아도 되서 방식 변경함


<br>

## 🌟 More
- _가능하면 이번주 중으로 위키에 AOP 로깅 적용한 내용 관련해서 올려두겠습니다!_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
