### PR TITLE
회원가입 기본 로직 작성

### DIFF
--- a/module-api/src/main/java/com/kernel360/commoncode/dto/CommonCodeDto.java
+++ b/module-api/src/main/java/com/kernel360/commoncode/dto/CommonCodeDto.java
@@ -1,10 +1,7 @@
 package com.kernel360.commoncode.dto;
 
 import com.kernel360.commoncode.entity.CommonCode;
-import com.kernel360.member.dto.MemberDto;
-import com.kernel360.member.entity.Member;
 
-import java.io.Serializable;
 import java.time.LocalDate;
 
 /**
@@ -23,7 +20,10 @@ public record CommonCodeDto(Integer codeNo,
 
                             LocalDate modifiedAt,
                             String modifiedBy) {
-    /** all binding **/
+    /**
+     * @param codeNo, codeName
+     * **/
+
     public static CommonCodeDto of(
             Integer codeNo,
             String codeName,

--- a/module-api/src/main/java/com/kernel360/member/config/AuditConfig.java
+++ b/module-api/src/main/java/com/kernel360/member/config/AuditConfig.java
@@ -1,0 +1,20 @@
+package com.kernel360.member.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Optional;
+
+@Configuration
+public class AuditConfig implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String createId = Optional.ofNullable(request.getParameter("id")).orElse("admin");
+
+        return Optional.of(createId);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -1,67 +1,38 @@
 package com.kernel360.member.controller;
 
+import ch.qos.logback.core.model.Model;
+import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.service.MemberService;
 import com.kernel360.utils.JWT;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/member/")
 public class MemberController {
-    @Autowired
-    private MemberService memberService;
-    @Autowired
-    private JWT jwt;
+
+    private final MemberService memberService;
+
+    /** 가입 **/
+    @PostMapping("/join")
+    public ResponseEntity<Model> joinMember (@ModelAttribute MemberDto joinRequestDto){
+
+        try{
+            memberService.joinMember(joinRequestDto);
+        }catch (IllegalArgumentException args){
+            log.error("가입에러발생", args);
+        }
+
+        return new ResponseEntity<>(null, HttpStatus.CREATED);
+    }
 
 
-//    /** 가입 **/
-//    @PostMapping("/join")
-//    public ResponseEntity<String> joinMember (@RequestParam MemberRequest){
-//
-//        if(memberService.joinMember(MemberRequest){
-//            //JWT 토큰 발급
-//            jwt.generateToken(MemberRequest.getId);
-//        }
-//
-//        return new ResponseEntity<>(null, HttpStatus.CREATED);
-//    }
-//    /** 로그인 **/
-//    @PostMapping("/login")
-//    public ResponseEntity<String> login (@RequestParam loginDTO){
-//
-//        memberService.login();
-//
-//        return new ResponseEntity<>(null,HttpStatus.OK);
-//    }
-//    /** 마이페이지 조회 **/
-//    @GetMapping("/info")
-//    public ResponseEntity<String> memberInfo (@RequestParam additionMemberDTO){
-//        return new ResponseEntity<>(null,HttpStatus.OK);
-//    }
-//
-//    /** 마이페이지 수정 -- ???? **/
-//    @PatchMapping("/info")
-//    public ResponseEntity<String> memberInfo (@RequestParam additionMemberDTO){
-//        return new ResponseEntity<>(null,HttpStatus.OK);
-//    }
-//
-//    /** 아이디 찾기 **/
-//    @PostMapping("/find-id")
-//    public ResponseEntity<String> findMemberById (@RequestParam memberDTO){
-//        return new ResponseEntity<>(null,HttpStatus.OK);
-//    }
-//
-//    /** 비밀번호 찾기 **/
-//    @PostMapping("/find-password")
-//    public ResponseEntity<String> findMemberByPassword (@RequestParam memberDTO){
-//        return new ResponseEntity<>(null,HttpStatus.OK);
-//    }
-//
-//    /** 비밀번호 변경 **/
-//    @PutMapping("/change-password")
-//    public ResponseEntity<String> changePassword (@RequestParam memberDTO){
-//        return new ResponseEntity<>(null,HttpStatus.OK);
-//    }
 }

--- a/module-api/src/main/java/com/kernel360/member/dto/MemberDto.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/MemberDto.java
@@ -19,6 +19,7 @@ public record MemberDto(Integer memberNo,
                         String modifiedBy
 ) {
 
+    /** New All **/
     public static MemberDto of(
             Integer memberNo,
             String id,
@@ -45,6 +46,27 @@ public record MemberDto(Integer memberNo,
         );
     }
 
+    /** joinMember **/
+    public static MemberDto of(
+            String id,
+            String email,
+            String password
+    ){
+        return new MemberDto(
+                null,
+                id,
+                email,
+                password,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    /** Entity -> DTO **/
     public static MemberDto from(Member entity) {
         return MemberDto.of(
                 entity.getMemberNo(),
@@ -60,6 +82,7 @@ public record MemberDto(Integer memberNo,
         );
     }
 
+    /** DTO -> Entity All binding **/
     public static Member toEntity(MemberDto memberDto) {
         return Member.of(
                 memberDto.memberNo,

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -1,52 +1,34 @@
 package com.kernel360.member.service;
 
+import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.entity.Member;
 import com.kernel360.member.repository.MemberRepository;
 import com.kernel360.utils.ConvertSHA256;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.sql.SQLDataException;
 
-import static javax.crypto.Cipher.SECRET_KEY;
-
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class MemberService {
-    private MemberRepository memberRepository;
 
-    public MemberService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
+    final private MemberRepository memberRepository;
+    /** 가입 로직 **/
+    public void joinMember(MemberDto requestDto){
+
+        String encodePassword = ConvertSHA256.convertToSHA256(requestDto.password());
+
+        Member entity = getNewJoinMemberEntity(requestDto,encodePassword);
+
+        memberRepository.save(entity);
     }
-//
-//    /** 가입 로직 **/
-//    public boolean joinMember(MemberDTO){
-//        String encodePassword;
-//        boolean result = false;
-//        try {
-//            encodePassword = ConvertSHA256.convertToSHA256(MemberDto.getPassword());
-//        }
-//        catch (RuntimeException noSearch){
-//            log.error("JoinMember :: no search param by " + noSearch.getStackTrace());
-//        }
-//
-//
-//        try {
-//            // DTO -> Entity 변환
-//            Member MemberEntity = new Member();
-//            memberRepository.save(MemberEntity);
-//            result = true;
-//            //success message
-//        }catch (SQLDataException sql){
-//            log.error("JoinMember :: save sql error by " + sql.getStackTrace());
-//        }
-//
-//        //jwt 키생성
-//
-//        //사용자 정보 jwt 키 db save
-//
-//        //토큰 return
-//
-//        return result;
-//    }
+
+    private Member getNewJoinMemberEntity (MemberDto dto, String password){
+        return Member.createJoinMember(dto.id(),dto.email(),password);
+    }
+
 //
 //    public void login(){
 //

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -1,0 +1,62 @@
+package com.kernel360.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kernel360.member.dto.MemberDto;
+import com.kernel360.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @MockBean
+    private MemberService memberService;
+
+
+    @BeforeEach
+    public void setup(){
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                      .addFilter(new CharacterEncodingFilter("UTF-8",true))
+                      .alwaysDo(print())
+                      .build();
+    }
+
+    @Test
+    @DisplayName("회원가입요청")
+    void 회원가입요청로직() throws Exception {
+
+        /** given 목데이터 세팅 **/
+        MemberDto memberDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String param = objectMapper.writeValueAsString(memberDto);
+
+        /** then **/
+        mockMvc.perform(MockMvcRequestBuilders.post("/member/join") //이 다음 restful
+                       .contentType(MediaType.APPLICATION_JSON)
+                       .content(param))
+           .andExpect(MockMvcResultMatchers.status().isCreated()) //기대 결과 상태값
+           .andReturn();
+    }
+
+}

--- a/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
@@ -1,0 +1,52 @@
+package com.kernel360.member.service;
+
+import com.kernel360.member.dto.MemberDto;
+import com.kernel360.member.entity.Member;
+import com.kernel360.member.repository.MemberRepository;
+import com.kernel360.utils.ConvertSHA256;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원가입_테스트")
+    void 회원가입_로직_테스트(){
+        /** given **/
+        MemberDto requestDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword");
+        //Member member = Member.builder().id(memberDto.id()).password(memberDto.password()).email(memberDto.email()).build();
+        Member member = new Member(requestDto.id(),requestDto.email(), requestDto.password());
+        /** when **/
+        memberRepository.save(member);
+        /** then **/
+        verify(memberRepository).save(member);
+    }
+
+    @Test
+    @DisplayName("암호화_메서드_테스트")
+    void 암호화_로직_테스트(){
+        /** given **/
+        String original = "this_is_test_text!";
+        String expect = "c4ea44dbb286170b5caa17b03ae978a874cdb6c6751ed11a2518acb5dc84e86e";
+
+        /** when **/
+        String convert = ConvertSHA256.convertToSHA256(original);
+
+        /** then **/
+        assertEquals(expect,convert);
+    }
+
+}

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'
+
+    implementation 'commons-codec:commons-codec:1.15'
 }
 
 tasks.named('test') {

--- a/module-common/src/main/java/com/kernel360/utils/ConvertSHA256.java
+++ b/module-common/src/main/java/com/kernel360/utils/ConvertSHA256.java
@@ -1,31 +1,13 @@
 package com.kernel360.utils;
 
 import lombok.extern.slf4j.Slf4j;
-
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import org.apache.commons.codec.digest.DigestUtils;
 
 @Slf4j
 public class ConvertSHA256 {
+
     public static String convertToSHA256(String word) {
-        String encodePassword = "";
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] encodedHash = digest.digest(word.getBytes());
-
-            StringBuilder hexString = new StringBuilder();
-            for (byte hashByte : encodedHash) {
-                String hex = Integer.toHexString(0xff & hashByte);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            encodePassword = hexString.toString();
-        } catch (NoSuchAlgorithmException algorithm) {
-            log.error("JoinMember :: not found algorithm by " + algorithm.getStackTrace());
-        }
-
-        return encodePassword;
+        return DigestUtils.sha256Hex(word);
     }
 }
+

--- a/module-domain/src/main/java/com/kernel360/base/BaseEntity.java
+++ b/module-domain/src/main/java/com/kernel360/base/BaseEntity.java
@@ -1,17 +1,20 @@
 package com.kernel360.base;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
     @Column(name = "created_at", nullable = false)

--- a/module-domain/src/main/java/com/kernel360/config/JpaConfig.java
+++ b/module-domain/src/main/java/com/kernel360/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.kernel360.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/module-domain/src/main/java/com/kernel360/member/entity/Member.java
+++ b/module-domain/src/main/java/com/kernel360/member/entity/Member.java
@@ -2,20 +2,20 @@ package com.kernel360.member.entity;
 
 import com.kernel360.base.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
-
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
-@Setter
 @Entity
 @Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "member_id_gen")
-    @SequenceGenerator(name = "member_id_gen", sequenceName = "member_member_no_seq")
+    @SequenceGenerator(name = "member_id_gen", sequenceName = "member_member_no_seq", allocationSize = 50)
     @Column(name = "member_no", nullable = false)
     private Integer memberNo;
 
@@ -38,17 +38,8 @@ public class Member extends BaseEntity {
         return new Member(memberNo, id, email, password, gender, birthdate);
     }
 
-    protected Member(){
-    }
-
-    private Member(
-            Integer memberNo,
-            String id,
-            String email,
-            String password,
-            String gender,
-            LocalDate birthdate
-    )    {
+    /** All Binding **/
+    private Member(Integer memberNo, String id, String email, String password, String gender, LocalDate birthdate) {
         this.memberNo = memberNo;
         this.id = id;
         this.email = email;
@@ -56,4 +47,17 @@ public class Member extends BaseEntity {
         this.gender = gender;
         this.birthdate = birthdate;
     }
+
+    /** joinMember **/
+    public static Member createJoinMember(String id, String email, String password){
+        return new Member(id,email,password);
+    }
+
+    /** joinMember Binding **/
+    public Member(String id, String email, String password){
+        this.id = id;
+        this.email = email;
+        this.password = password;
+    }
+
 }


### PR DESCRIPTION
단위테스트 통과
인수테스트 통과

## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
회원가입 기본 로직을 작성했습니다.

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - BaseEntity :: 작성자, 수정자 빈값일 경우 자동 맵핑을 위해 애노테이션 추가, AuditConfig  추가, JPAConfig 추가
![스크린샷 2024-01-04 112728](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/45c45d58-07a7-4a72-b254-7d246843bce9)

![스크린샷 2024-01-04 112734](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/355edb4b-ce60-492c-bbcf-4a9fb421201d)


 - 현준님이 올리신 코드중에 Member entity에 대해 수정을 했습니다.
protected  빈 생성자를 사용해도 되지만, 찬규님이 PR에 올려주신 NoArgs 블라블라 애노테이션으로 처리가 가능하고
Setter 애노테이션이 있어 삭제했습니다.
 - [BEFORE]
![스크린샷 2024-01-04 112816](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/9a8a4847-0b62-4fec-817c-77004bd757f8)
 - [AFTER]
![스크린샷 2024-01-04 112819](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/fa385c73-9b3d-4de1-a6ae-5b0b855b6388)

그 외는 기본적인 가입로직이므로 소스코드 확인하시면 되겠습니다.

<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>
 _파라메터 받은 후 JPA를 통한 저장 로직 작성
 _ INSERT, UPDATE시 테이블 암호화 트리거 작성
 _ INSERT, UPDATE시 테이블 복호화 VIEW 작성
 _JWT 토큰을 발급 처리하여 return 처리 -> 로그인 로직으로 이동

---


### 📋 커밋 전 체크리스트
- [x] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
