### PR TITLE
[feat] add JasyptEncryptor to module-common

### DIFF
--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -2,8 +2,8 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     # local docker db
-    url: ENC(ulGy/5rB4Y7rD0wHbwR21rLG/jT1Lkm02LgSbHuE9n9mmxZmv0FenoE8dD89qMadlLdy+gAf24ulHM3z9/JYrQ==)
-    username: ENC(gv8+vDAseDkw87FNUNmFQVdk5dTBu0GQ71VBBuUyeIY=)
+    url: ENC(DPvTlKCZniOLZz5QHwB2I1p6FbeyEhWeo6DXSHL7kq8idfthgqkC/VJX78osBC5D/hzFwdXGDkxWUZ2euYPrAA==)
+    username: ENC(izKjVNL/2x4aTDQeLxQg4VU0v5kAKduTrnVq7LUa80U=)
     password: ENC(VcPYkEOg9OzuwNw1UeYOgLqKsRkFoRUHwjRcxZzGgZQ=)
   jpa:
     show-sql: true

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+    // jasypt
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'

--- a/module-common/src/main/java/com/kernel360/utils/jasypt/EncryptionConfiguration.java
+++ b/module-common/src/main/java/com/kernel360/utils/jasypt/EncryptionConfiguration.java
@@ -1,0 +1,25 @@
+package com.kernel360.utils.jasypt;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class EncryptionConfiguration {
+    @Primary
+    @Bean("washpediaEncryptorBean")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword("이 곳에 secret-key를 넣으세요"); // ""
+        config.setAlgorithm("PBEWithMD5AndTripleDES");
+        config.setIvGeneratorClassName("org.jasypt.iv.RandomIvGenerator");
+        config.setPoolSize("1");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+
+}

--- a/module-common/src/main/java/com/kernel360/utils/jasypt/JasyptEncryptor.java
+++ b/module-common/src/main/java/com/kernel360/utils/jasypt/JasyptEncryptor.java
@@ -1,0 +1,30 @@
+package com.kernel360.utils.jasypt;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class JasyptEncryptor implements CommandLineRunner {
+    private final StringEncryptor stringEncryptor;
+
+    public JasyptEncryptor(@Qualifier("washpediaEncryptorBean") StringEncryptor stringEncryptor) {
+        this.stringEncryptor = stringEncryptor;
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(JasyptEncryptor.class, args);
+    }
+
+    @Override
+    public void run(String... args) {
+        String url = "암호화 할 문자열을 입력하세요";
+        String encryptedUrl = stringEncryptor.encrypt(url);
+
+        System.out.println("[Original] : " + url);
+        System.out.println("[Encrypted] : " + "ENC(" + encryptedUrl + ")");
+        System.out.println("[Decrypted] : " + stringEncryptor.decrypt(encryptedUrl));
+    }
+}


### PR DESCRIPTION
## 💡 Motivation and Context
`Jasypt 암호문을 생성하고 복호화하여 확인하는 것에 불편함을 느껴 Jasypt 암호화 기능을 공유하였습니다.`

<br>

## 🔨 Modified
> common 모듈안에 JasyptEncryptor가 추가되었습니다.
  - sercret 키를 직접 입력하고, 암호화 할 문자열을 직접 입력하여 실행시키면 콘솔에서 확인할 수 있습니다.
  - 원격 저장소에 커밋할 때, 암호문 원문이 포함되지 않았는지 특별히 신경써주세요.

<br>

## 🌟 More
- _module-api를 실행시키면 같이 실행되기 때문에, 차후에 시간이 날 때 별도의 JAR 파일로 만들어 다시 공유드리겠습니다._

<br>

---


### 📋 커밋 전 체크리스트
- [x] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
