### PR TITLE
로그인 기본 로직 작성

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -2,16 +2,37 @@ package com.kernel360.member.controller;
 
 
 import com.kernel360.member.dto.MemberDto;
+import com.kernel360.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/member")
 public class MemberController {
+
+    private final MemberService memberService;
     @PostMapping("/join")
-    public String signup(@RequestBody MemberDto memberDto ) {
-        return "member/signup";
+    public ResponseEntity joinMember(@ModelAttribute MemberDto joinRequestDto ) {
+
+        try{
+            memberService.joinMember(joinRequestDto);
+        }catch (IllegalArgumentException args){
+            log.error("가입에러발생", args);
+        }
+
+        return new ResponseEntity(null,HttpStatus.CREATED);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<MemberDto> login (@ModelAttribute MemberDto loginDto) {
+
+        MemberDto memberInfo = memberService.login(loginDto);
+
+        return new ResponseEntity<>(memberInfo, HttpStatus.ACCEPTED);
     }
 }

--- a/module-api/src/main/java/com/kernel360/member/dto/MemberDto.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/MemberDto.java
@@ -16,7 +16,8 @@ public record MemberDto(Integer memberNo,
                         LocalDate createdAt,
                         String createdBy,
                         LocalDate modifiedAt,
-                        String modifiedBy
+                        String modifiedBy,
+                        String jwtToken
 ) {
 
     public static MemberDto of(
@@ -29,7 +30,8 @@ public record MemberDto(Integer memberNo,
             LocalDate createdAt,
             String createdBy,
             LocalDate modifiedAt,
-            String modifiedBy
+            String modifiedBy,
+            String jwtToken
     ) {
         return new MemberDto(
                 memberNo,
@@ -41,7 +43,8 @@ public record MemberDto(Integer memberNo,
                 createdAt,
                 createdBy,
                 modifiedAt,
-                modifiedBy
+                modifiedBy,
+                jwtToken
         );
     }
 
@@ -56,7 +59,8 @@ public record MemberDto(Integer memberNo,
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
-                entity.getModifiedBy()
+                entity.getModifiedBy(),
+                null
         );
     }
 
@@ -68,6 +72,64 @@ public record MemberDto(Integer memberNo,
                 this.password,
                 this.gender,
                 this.birthdate
+        );
+    }
+
+    /** joinMember **/
+    public static MemberDto of(
+            String id,
+            String email,
+            String password
+    ){
+        return new MemberDto(
+                null,
+                id,
+                email,
+                password,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    /** Login Binding **/
+    public static MemberDto login(Member entity,String jwtToken) {
+        return MemberDto.of(
+                entity.getMemberNo(),
+                entity.getId(),
+                entity.getEmail(),
+                null,
+                entity.getGender(),
+                entity.getBirthdate(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy(),
+                jwtToken
+        );
+    }
+
+    /** Request Login **/
+    public static MemberDto of(
+            String id,
+            String password
+    ){
+        return new MemberDto(
+                null,
+                id,
+                null,
+                password,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
         );
     }
 }

--- a/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
@@ -1,52 +1,134 @@
-//package com.kernel360.member.service;
-//
-//import com.kernel360.member.dto.MemberDto;
-//import com.kernel360.member.entity.Member;
-//import com.kernel360.member.repository.MemberRepository;
-//import com.kernel360.utils.ConvertSHA256;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import static org.mockito.Mockito.verify;
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class MemberServiceTest {
-//
-//    @Mock
-//    private MemberRepository memberRepository;
-//
-//    @InjectMocks
-//    private MemberService memberService;
-//
-//    @Test
-//    @DisplayName("회원가입_테스트")
-//    void 회원가입_로직_테스트(){
-//        /** given **/
-//        MemberDto requestDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword");
-//        //Member member = Member.builder().id(memberDto.id()).password(memberDto.password()).email(memberDto.email()).build();
-//        Member member = new Member(requestDto.id(),requestDto.email(), requestDto.password());
-//        /** when **/
-//        memberRepository.save(member);
-//        /** then **/
-//        verify(memberRepository).save(member);
-//    }
-//
-//    @Test
-//    @DisplayName("암호화_메서드_테스트")
-//    void 암호화_로직_테스트(){
-//        /** given **/
-//        String original = "this_is_test_text!";
-//        String expect = "c4ea44dbb286170b5caa17b03ae978a874cdb6c6751ed11a2518acb5dc84e86e";
-//
-//        /** when **/
-//        String convert = ConvertSHA256.convertToSHA256(original);
-//
-//        /** then **/
-//        assertEquals(expect,convert);
-//    }
-//
-//}
+package com.kernel360.member.service;
+
+import com.kernel360.auth.entity.Auth;
+import com.kernel360.auth.repository.AuthRepository;
+import com.kernel360.member.dto.MemberDto;
+import com.kernel360.member.entity.Member;
+import com.kernel360.member.repository.MemberRepository;
+import com.kernel360.utils.ConvertSHA256;
+import com.kernel360.utils.JWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JWT jwt;
+
+    @Mock
+    private AuthRepository authRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private ConvertSHA256 convertSHA256;
+
+    @BeforeEach
+    public void init() {
+
+        convertSHA256 = mock(ConvertSHA256.class);
+    }
+
+    @Test
+    @DisplayName("회원가입_테스트")
+    void 회원가입_로직_테스트(){
+
+        /** given **/
+        MemberDto requestDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword");
+        Member member = memberService.getNewJoinMemberEntity(requestDto);
+
+        /** when **/
+        memberRepository.save(member);
+
+        /** then **/
+        verify(memberRepository).save(member);
+    }
+
+    @Test
+    @DisplayName("암호화_메서드_테스트")
+    void 암호화_로직_테스트(){
+
+        /** given **/
+        String original = "this_is_test_text!";
+        String expect = "c4ea44dbb286170b5caa17b03ae978a874cdb6c6751ed11a2518acb5dc84e86e";
+
+        /** when **/
+        String convert = convertSHA256.convertToSHA256(original);
+
+        /** then **/
+        assertEquals(expect,convert);
+    }
+
+    @Test
+    @DisplayName("로그인시_회원정보조회_후_토큰발급이_제대로_수행되는지_테스트한다.")
+    void 로그인_테스트(){
+
+        /** given **/
+        MemberDto loginDto = MemberDto.of("test03","1234qwer");
+        Member mockLoginEntity = Member.loginMember(loginDto.id(), loginDto.password());
+        Member mockEntity = Member.of(502,loginDto.id(),"test03@naver.com","0eb9de69892882d54516e03e30098354a2e39cea36adab275b6300c737c942fd",null,null);
+        String mockToken = "dummy_token";
+
+        /** stub **/
+        when(memberRepository.findAllByIdAndPassword(any(), any())).thenReturn(mockEntity);
+
+        /** when **/
+        Member loginEntity = mockLoginEntity;
+        Member memberEntity = memberRepository.findAllByIdAndPassword(loginEntity.getId(), loginEntity.getPassword());
+        String token = mockToken;
+        MemberDto memberInfo = MemberDto.login(memberEntity, token);
+
+        /** then , given-stub의 대한 리팩터링이 필요한 것으로 판단 됨. **/
+        assertNotNull(memberInfo,"로그인을 하면 회원정보를 가지고 있어야 함.");
+        assertEquals("dummy_token",token);
+        assertEquals(502,memberEntity.getMemberNo());
+        assertNull(memberInfo.password(),"비밀번호는 빈값이어야함.");
+    }
+
+    @Test
+    @DisplayName("로그인시_토큰발급_및_토큰정보_저장을_테스트한다.")
+    void 토큰_발급_저장_테스트(){
+
+        /** given **/
+        Member memberEntity = Member.of(502,"test03",null,null,null,null);
+        String mockToken = "mockToken";
+        String convertToken = "convert_mock_token";
+        Auth auth = Auth.jwt(null,502, mockToken);
+
+        /** stub **/
+        when(jwt.generateToken(anyString())).thenReturn(mockToken);
+        //when(convertSHA256.convertToSHA256(anyString())).thenReturn(convertToken);
+        when(authRepository.findOneByMemberNo(anyInt())).thenReturn(auth);
+        //when(this.createAuthJwt(anyInt(),any())).thenReturn(auth);
+
+        /** when **/
+        String token = jwt.generateToken(memberEntity.getId()); // 토큰 생성은 mockToken으로 잘 가져옴.
+        String encryptToken = convertSHA256.convertToSHA256(token); // mock 객체로 세팅을 했지만 얘는 왜 실제 로직을 타는지는 몰?루 line:113
+        Auth authJwt = authRepository.findOneByMemberNo(memberEntity.getMemberNo());
+
+        if(authJwt == null) {
+            authJwt = memberService.createAuthJwt(null, memberEntity.getMemberNo(), encryptToken);
+        }else{
+            authJwt = memberService.createAuthJwt(authJwt.getAuthNo(),authJwt.getMemberNo(),encryptToken);
+        }
+        authRepository.save(authJwt);
+
+        /** then , given - stub의 대한 리팩터링이 필요하다 판단 됨. **/
+        verify(authRepository).save(authJwt);
+        assertNotNull(token,"토큰 생성 결과 값은 null이 아니어야 함.");
+    }
+
+}

--- a/module-common/src/main/java/com/kernel360/utils/ConvertSHA256.java
+++ b/module-common/src/main/java/com/kernel360/utils/ConvertSHA256.java
@@ -2,8 +2,10 @@ package com.kernel360.utils;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
 public class ConvertSHA256 {
 
     public static String convertToSHA256(String word) {

--- a/module-common/src/main/java/com/kernel360/utils/JWT.java
+++ b/module-common/src/main/java/com/kernel360/utils/JWT.java
@@ -11,7 +11,7 @@ import java.util.Date;
 @Component
 public class JWT {
     private static final Key SECRET_KEY = Keys.secretKeyFor(io.jsonwebtoken.SignatureAlgorithm.HS256);
-    private static final long EXPIRATION_TIME = 1000 * 60 * 60 * 12;
+    private static final long EXPIRATION_TIME = 1000 * 60 * 15; //15분
 
     public String generateToken(String ID) {
         return Jwts.builder()

--- a/module-domain/src/main/java/com/kernel360/auth/entity/Auth.java
+++ b/module-domain/src/main/java/com/kernel360/auth/entity/Auth.java
@@ -1,0 +1,66 @@
+package com.kernel360.auth.entity;
+
+import com.kernel360.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@Entity
+@DynamicUpdate
+@Table(name = "auth")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Auth extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "auth_id_gen")
+    @SequenceGenerator(name = "auth_id_gen", sequenceName = "auth_auth_no_seq")
+    @Column(name = "auth_no", nullable = false)
+    private Integer authNo;
+
+    @Column(name = "member_no")
+    private Integer memberNo;
+
+    @Column(name = "jwt_token")
+    private String jwtToken;
+
+    @Column(name = "sns_token")
+    private String snsToken;
+
+
+    public static Auth of(Integer authNo, Integer memberNo, String jwtToken, String snsToken){
+
+        return new Auth(authNo, memberNo, jwtToken, snsToken);
+    }
+
+    /** All Binding **/
+    private Auth (Integer authNo, Integer memberNo, String jwtToken, String snsToken){
+        this.authNo = authNo;
+        this.memberNo = memberNo;
+        this.jwtToken = jwtToken;
+        this.snsToken = snsToken;
+    }
+
+
+    public static Auth jwt(Integer authNo, Integer memberNo, String jwtToken){
+
+        return new Auth(authNo, memberNo, jwtToken);
+    }
+
+    /** JWT **/
+    private Auth (Integer authNo, Integer memberNo, String jwtToken){
+        this.authNo = authNo;
+        this.memberNo = memberNo;
+        this.jwtToken = jwtToken;
+    }
+
+    public void updateJwt(String encryptToken) {
+        this.jwtToken = encryptToken;
+    }
+
+    public void createJwt(Integer memberNo, String encryptToken) {
+        this.memberNo = memberNo;
+        this.jwtToken = encryptToken;
+    }
+}

--- a/module-domain/src/main/java/com/kernel360/auth/repository/AuthRepository.java
+++ b/module-domain/src/main/java/com/kernel360/auth/repository/AuthRepository.java
@@ -1,0 +1,11 @@
+package com.kernel360.auth.repository;
+
+import com.kernel360.auth.entity.Auth;
+import jakarta.persistence.Id;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthRepository extends JpaRepository <Auth, Id> {
+
+    Auth findOneByMemberNo(Integer memberNo);
+
+}

--- a/module-domain/src/main/java/com/kernel360/base/BaseEntity.java
+++ b/module-domain/src/main/java/com/kernel360/base/BaseEntity.java
@@ -1,15 +1,20 @@
 package com.kernel360.base;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 
 @Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
     private static final int MAX_STRING_LENGTH = 255;
@@ -18,7 +23,7 @@ public class BaseEntity {
     @CreatedDate
     private LocalDate createdAt;
 
-    @Column(name = "created_by", nullable = false, length = MAX_STRING_LENGTH)
+    @Column(name = "created_by", nullable = false, length = MAX_STRING_LENGTH, updatable = false)
     @CreatedBy
     private String createdBy;
 

--- a/module-domain/src/main/java/com/kernel360/member/entity/Member.java
+++ b/module-domain/src/main/java/com/kernel360/member/entity/Member.java
@@ -2,16 +2,16 @@ package com.kernel360.member.entity;
 
 import com.kernel360.base.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
-
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
-@Setter
 @Entity
 @Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "member_id_gen")
@@ -35,12 +35,11 @@ public class Member extends BaseEntity {
     private LocalDate birthdate;
 
     public static Member of(Integer memberNo, String id, String email, String password, String gender, LocalDate birthdate) {
+
         return new Member(memberNo, id, email, password, gender, birthdate);
     }
 
-    protected Member(){
-    }
-
+    /** All Binding **/
     private Member(
             Integer memberNo,
             String id,
@@ -56,4 +55,30 @@ public class Member extends BaseEntity {
         this.gender = gender;
         this.birthdate = birthdate;
     }
+
+    /** joinMember **/
+    public static Member createJoinMember(String id, String email, String password){
+
+        return new Member(id,email,password);
+    }
+
+    /** joinMember Binding **/
+    private Member(String id, String email, String password){
+        this.id = id;
+        this.email = email;
+        this.password = password;
+    }
+
+    /** loginMember **/
+    public static Member loginMember(String id, String password){
+
+        return new Member(id,password);
+    }
+
+    /** loginMember Binding **/
+    private Member(String id, String password){
+        this.id = id;
+        this.password = password;
+    }
+
 }

--- a/module-domain/src/main/java/com/kernel360/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/com/kernel360/member/repository/MemberRepository.java
@@ -5,4 +5,6 @@ import jakarta.persistence.Id;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository <Member, Id> {
+
+    Member findAllByIdAndPassword(String id, String password);
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
로그인 기본 로직 구현, 테스트코드 작성 및 통과, 인수테스트 통과
<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  -  현준님 PR 받은 후 충돌 발생 된 코드들에 대해 다시 merge 처리 하였습니다.
  -  로그인시 가입했던 ID / PW 확인 후 JWT 토큰 발급처리합니다.
  
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/6e1e8fcb-5755-4ef7-8b83-fadad3479f47)
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/98ad4e58-f51e-4292-acf8-71a8c1ed65f7)

  - 토큰은 1가지만 발급하며, 발급 된 토큰은 한번 더 단방향 암호화 하여 인증 테이블에 저장됩니다. 토큰의 위변조가 발생시 해싱값이 불일치하게 되므로 토큰 갱신이 불가, 로그인으로 튕깁니다. (이 기능이 유효성검사에 들어가야함.)
  -  키 생성 암호화는 Keys.secretKeyFor(io.jsonwebtoken.SignatureAlgorithm.HS256)를 이용하였습니다.
  - 토큰의 유효시간은 15분으로 설정하였습니다.

<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
    - 인증테이블 생성 SQL flyway update
    - 회원 테이블의 대한 암호화 및 VIEW 복호화
    - 회원가입시 ID 및 email 중복 조회 체크 API
    - globalFilter를 적용하여 사용자가 보유중인 JWT토큰 만료 2분전, 토큰 유효성 검사 로직이 필요합니다.
    - 로그아웃, ID찾기, PW 재설정 API

    - 테스트코드가 좀 맘에 들지않아 추후 리팩터링이 필요해보입니다.

---


### 📋 커밋 전 체크리스트
- [ √ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ √ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
