### PR TITLE
Refactor login :: 로그인 리팩터링

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -7,7 +7,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -16,23 +19,24 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
-    @PostMapping("/join")
-    public ResponseEntity joinMember(@ModelAttribute MemberDto joinRequestDto ) {
 
-        try{
+    @PostMapping("/join")
+    public ResponseEntity<String> joinMember(@ModelAttribute MemberDto joinRequestDto) {
+
+        try {
             memberService.joinMember(joinRequestDto);
-        }catch (IllegalArgumentException args){
+        } catch (IllegalArgumentException args) {
             log.error("가입에러발생", args);
         }
 
-        return new ResponseEntity(null,HttpStatus.CREATED);
+        return new ResponseEntity<>("", HttpStatus.CREATED);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<MemberDto> login (@ModelAttribute MemberDto loginDto) {
+    public ResponseEntity<MemberDto> login(@ModelAttribute MemberDto loginDto) {
 
         MemberDto memberInfo = memberService.login(loginDto);
 
-        return new ResponseEntity<>(memberInfo, HttpStatus.ACCEPTED);
+        return new ResponseEntity<>(memberInfo, HttpStatus.OK);
     }
 }

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 
 @Slf4j
 @Service
@@ -18,63 +20,64 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final JWT jwt;
-    private final ConvertSHA256 convertSHA256;
     private final AuthRepository authRepository;
     private final MemberRepository memberRepository;
 
-    /** 가입 **/
-    public void joinMember(MemberDto requestDto){
+    /**
+     * 가입
+     **/
+    public void joinMember(MemberDto requestDto) {
 
         Member entity = getNewJoinMemberEntity(requestDto);
 
         memberRepository.save(entity);
     }
 
-    protected Member getNewJoinMemberEntity(MemberDto requestDto){
+    protected Member getNewJoinMemberEntity(MemberDto requestDto) {
 
-        String encodePassword = convertSHA256.convertToSHA256(requestDto.password());
+        String encodePassword = ConvertSHA256.convertToSHA256(requestDto.password());
 
         return Member.createJoinMember(requestDto.id(), requestDto.email(), encodePassword);
     }
 
-    /** 로그인 **/
+    /**
+     * 로그인
+     **/
     public MemberDto login(MemberDto loginDto) {
 
         Member loginEntity = getReqeustLoginEntity(loginDto);
-        Member memberEntity = memberRepository.findAllByIdAndPassword(loginEntity.getId(), loginEntity.getPassword());
-        String token = printJwtToken(memberEntity);
-
-        MemberDto memberInfo = MemberDto.login(memberEntity, token);
-
-        return memberInfo;
-    }
-
-    private Member getReqeustLoginEntity(MemberDto loginDto) {
-        String encodePassword = convertSHA256.convertToSHA256(loginDto.password());
-        return Member.loginMember(loginDto.id(),encodePassword );
-    }
-
-    /** 토큰 발급, 이전 토큰에 따른 update or insert **/
-    public String printJwtToken(Member memberEntity){
-
+        Member memberEntity = memberRepository.findOneByIdAndPassword(loginEntity.getId(), loginEntity.getPassword());
         String token = jwt.generateToken(memberEntity.getId());
-        String encryptToken = convertSHA256.convertToSHA256(token);
+        String encryptToken = ConvertSHA256.convertToSHA256(token);
         Auth authJwt = authRepository.findOneByMemberNo(memberEntity.getMemberNo());
 
-        if (authJwt == null) {
-            authJwt = createAuthJwt(null, memberEntity.getMemberNo(),encryptToken);
-        } else {
-            authJwt.updateJwt(encryptToken);
-        }
+        //결과 없으면 entity로 신규 생성
+        authJwt = Optional.ofNullable(authJwt)
+                          .map(modifyAuth -> modifyAuthJwt(modifyAuth, encryptToken))
+                          .orElseGet(() -> createAuthJwt(memberEntity.getMemberNo(), encryptToken));
+
         authRepository.save(authJwt);
 
-
-        return token;
+        return MemberDto.login(memberEntity, token);
     }
 
-    protected Auth createAuthJwt(Integer authNo, Integer memberNo, String encryptToken) {
+    protected Auth modifyAuthJwt(Auth modifyAuth, String encryptToken) {
+        modifyAuth.updateJwt(encryptToken);
+
+        return modifyAuth;
+    }
+
+    protected Auth createAuthJwt(Integer memberNo, String encryptToken) {
 
         return Auth.of(null, memberNo, encryptToken, null);
     }
+
+
+    private Member getReqeustLoginEntity(MemberDto loginDto) {
+        String encodePassword = ConvertSHA256.convertToSHA256(loginDto.password());
+
+        return Member.loginMember(loginDto.id(), encodePassword);
+    }
+
 
 }

--- a/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -44,7 +46,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원가입_테스트")
-    void 회원가입_로직_테스트(){
+    void 회원가입_로직_테스트() {
 
         /** given **/
         MemberDto requestDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword");
@@ -59,7 +61,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("암호화_메서드_테스트")
-    void 암호화_로직_테스트(){
+    void 암호화_로직_테스트() {
 
         /** given **/
         String original = "this_is_test_text!";
@@ -69,66 +71,63 @@ class MemberServiceTest {
         String convert = convertSHA256.convertToSHA256(original);
 
         /** then **/
-        assertEquals(expect,convert);
+        assertEquals(expect, convert);
     }
 
     @Test
     @DisplayName("로그인시_회원정보조회_후_토큰발급이_제대로_수행되는지_테스트한다.")
-    void 로그인_테스트(){
+    void 로그인_테스트() {
 
         /** given **/
-        MemberDto loginDto = MemberDto.of("test03","1234qwer");
+        MemberDto loginDto = MemberDto.of("test03", "1234qwer");
         Member mockLoginEntity = Member.loginMember(loginDto.id(), loginDto.password());
-        Member mockEntity = Member.of(502,loginDto.id(),"test03@naver.com","0eb9de69892882d54516e03e30098354a2e39cea36adab275b6300c737c942fd",null,null);
+        Member mockEntity = Member.of(502, loginDto.id(), "test03@naver.com", "0eb9de69892882d54516e03e30098354a2e39cea36adab275b6300c737c942fd", null, null);
         String mockToken = "dummy_token";
 
         /** stub **/
-        when(memberRepository.findAllByIdAndPassword(any(), any())).thenReturn(mockEntity);
+        when(memberRepository.findOneByIdAndPassword(any(), any())).thenReturn(mockEntity);
 
         /** when **/
         Member loginEntity = mockLoginEntity;
-        Member memberEntity = memberRepository.findAllByIdAndPassword(loginEntity.getId(), loginEntity.getPassword());
+        Member memberEntity = memberRepository.findOneByIdAndPassword(loginEntity.getId(), loginEntity.getPassword());
         String token = mockToken;
         MemberDto memberInfo = MemberDto.login(memberEntity, token);
 
         /** then , given-stub의 대한 리팩터링이 필요한 것으로 판단 됨. **/
-        assertNotNull(memberInfo,"로그인을 하면 회원정보를 가지고 있어야 함.");
-        assertEquals("dummy_token",token);
-        assertEquals(502,memberEntity.getMemberNo());
-        assertNull(memberInfo.password(),"비밀번호는 빈값이어야함.");
+        assertNotNull(memberInfo, "로그인을 하면 회원정보를 가지고 있어야 함.");
+        assertEquals("dummy_token", token);
+        assertEquals(502, memberEntity.getMemberNo());
+        assertNull(memberInfo.password(), "비밀번호는 빈값이어야함.");
     }
 
     @Test
     @DisplayName("로그인시_토큰발급_및_토큰정보_저장을_테스트한다.")
-    void 토큰_발급_저장_테스트(){
+    void 토큰_발급_저장_테스트() {
 
         /** given **/
-        Member memberEntity = Member.of(502,"test03",null,null,null,null);
+        Member memberEntity = Member.of(502, "test03", null, null, null, null);
         String mockToken = "mockToken";
-        String convertToken = "convert_mock_token";
-        Auth auth = Auth.jwt(null,502, mockToken);
+        Auth auth = Auth.jwt(null, 502, mockToken);
 
         /** stub **/
         when(jwt.generateToken(anyString())).thenReturn(mockToken);
-        //when(convertSHA256.convertToSHA256(anyString())).thenReturn(convertToken);
         when(authRepository.findOneByMemberNo(anyInt())).thenReturn(auth);
-        //when(this.createAuthJwt(anyInt(),any())).thenReturn(auth);
 
         /** when **/
-        String token = jwt.generateToken(memberEntity.getId()); // 토큰 생성은 mockToken으로 잘 가져옴.
-        String encryptToken = convertSHA256.convertToSHA256(token); // mock 객체로 세팅을 했지만 얘는 왜 실제 로직을 타는지는 몰?루 line:113
+        String token = jwt.generateToken(memberEntity.getId()); //mockToken return 정상 수행 확인
+        String encryptToken = convertSHA256.convertToSHA256(token); //해싱부분은 정적메소드여서 그런지 stub이 안됨...(?)
         Auth authJwt = authRepository.findOneByMemberNo(memberEntity.getMemberNo());
 
-        if(authJwt == null) {
-            authJwt = memberService.createAuthJwt(null, memberEntity.getMemberNo(), encryptToken);
-        }else{
-            authJwt = memberService.createAuthJwt(authJwt.getAuthNo(),authJwt.getMemberNo(),encryptToken);
-        }
+        authJwt = Optional.ofNullable(authJwt)
+                          .map(modifyAuth -> memberService.modifyAuthJwt(modifyAuth, encryptToken))
+                          .orElseGet(() -> memberService.createAuthJwt(memberEntity.getMemberNo(), encryptToken));
+
         authRepository.save(authJwt);
 
         /** then , given - stub의 대한 리팩터링이 필요하다 판단 됨. **/
         verify(authRepository).save(authJwt);
-        assertNotNull(token,"토큰 생성 결과 값은 null이 아니어야 함.");
+        assertNotNull(token, "토큰 생성 결과 값은 null이 아니어야 함.");
+        assertEquals("D8A90363565890A7BD5E3FF42CFFDE851C8B532C60756EBBB837560DB3A011A7".toLowerCase(), encryptToken);
     }
 
 }

--- a/module-common/src/main/java/com/kernel360/utils/ConvertSHA256.java
+++ b/module-common/src/main/java/com/kernel360/utils/ConvertSHA256.java
@@ -1,15 +1,17 @@
 package com.kernel360.utils;
 
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
+@NoArgsConstructor
 public class ConvertSHA256 {
 
     public static String convertToSHA256(String word) {
+
         return DigestUtils.sha256Hex(word);
     }
+
 }
 

--- a/module-common/src/main/java/com/kernel360/utils/JWT.java
+++ b/module-common/src/main/java/com/kernel360/utils/JWT.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Member;
 import java.security.Key;
 import java.util.Date;
 

--- a/module-common/src/main/java/com/kernel360/utils/JWT.java
+++ b/module-common/src/main/java/com/kernel360/utils/JWT.java
@@ -5,17 +5,18 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.Member;
 import java.security.Key;
 import java.util.Date;
 
 @Component
 public class JWT {
     private static final Key SECRET_KEY = Keys.secretKeyFor(io.jsonwebtoken.SignatureAlgorithm.HS256);
-    private static final long EXPIRATION_TIME = 1000 * 60 * 15; //15분
+    private static final long EXPIRATION_TIME = (long) 1000 * 60 * 15; //15분
 
-    public String generateToken(String ID) {
+    public String generateToken(String entityId) {
         return Jwts.builder()
-                .setSubject(ID)
+                .setSubject(entityId)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .signWith(SECRET_KEY)

--- a/module-domain/src/main/java/com/kernel360/auth/entity/Auth.java
+++ b/module-domain/src/main/java/com/kernel360/auth/entity/Auth.java
@@ -29,13 +29,18 @@ public class Auth extends BaseEntity {
     private String snsToken;
 
 
-    public static Auth of(Integer authNo, Integer memberNo, String jwtToken, String snsToken){
+    /**
+     * all create
+     **/
+    public static Auth of(Integer authNo, Integer memberNo, String jwtToken, String snsToken) {
 
         return new Auth(authNo, memberNo, jwtToken, snsToken);
     }
 
-    /** All Binding **/
-    private Auth (Integer authNo, Integer memberNo, String jwtToken, String snsToken){
+    /**
+     * all binding
+     **/
+    private Auth(Integer authNo, Integer memberNo, String jwtToken, String snsToken) {
         this.authNo = authNo;
         this.memberNo = memberNo;
         this.jwtToken = jwtToken;
@@ -43,13 +48,15 @@ public class Auth extends BaseEntity {
     }
 
 
-    public static Auth jwt(Integer authNo, Integer memberNo, String jwtToken){
+    public static Auth jwt(Integer authNo, Integer memberNo, String jwtToken) {
 
         return new Auth(authNo, memberNo, jwtToken);
     }
 
-    /** JWT **/
-    private Auth (Integer authNo, Integer memberNo, String jwtToken){
+    /**
+     * JWT
+     **/
+    private Auth(Integer authNo, Integer memberNo, String jwtToken) {
         this.authNo = authNo;
         this.memberNo = memberNo;
         this.jwtToken = jwtToken;
@@ -59,8 +66,4 @@ public class Auth extends BaseEntity {
         this.jwtToken = encryptToken;
     }
 
-    public void createJwt(Integer memberNo, String encryptToken) {
-        this.memberNo = memberNo;
-        this.jwtToken = encryptToken;
-    }
 }

--- a/module-domain/src/main/java/com/kernel360/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/com/kernel360/member/repository/MemberRepository.java
@@ -4,7 +4,7 @@ import com.kernel360.member.entity.Member;
 import jakarta.persistence.Id;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository <Member, Id> {
+public interface MemberRepository extends JpaRepository<Member, Id> {
 
-    Member findAllByIdAndPassword(String id, String password);
+    Member findOneByIdAndPassword(String id, String password);
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
 - PR 내용 반영 및 소나린트 이슈 최대한 적용 하였습니다.
 


<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
 - printJwtToken 메서드가 기능면에서 중복되어 없애고, login에서 보다 간결하게 구현되도록 수정하였습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/fc2065a6-bc99-45bb-9bd8-14953347cf6f)

 - Ctrl + Alt + L 을 이용한 코드라인 정리 수행 하였습니다.
 - member 엔티티 조회시 all -> one으로 수정하였습니다.
 - auth 엔티티에서 쓰이지 않는 불필요 코드 삭제하였습니다.
 - controller에서 응답 코드 수정 하였습니다.
 - ConvertSHA256의 경우 컴포넌트 빈 등록 후 싱글톤보다 정적메서드 호출이 좋다고 코맨트가 있어 수정하였습니다.
 (정적메서드가 싱글톤보다 더 작은 단위의 고정된 관리라고 합니다.)
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/bf04b2b3-5cb3-4df4-8d75-5baefb7fc80b)
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/e44a40c9-4a94-4228-8118-13606413d6c6)
위 이미지에서 '프로그램 종료'는 메서드 return이 아닌, 서버 종료를 뜻합니다.
<br>

## 🌟 More
-인증테이블 생성 SQL flyway update

- 회원 테이블의 대한 암호화 및 VIEW 복호화

- 회원가입시 ID 및 email 중복 조회 체크 API

- globalFilter를 적용하여 사용자가 보유중인 JWT토큰 만료 2분전, 토큰 유효성 검사 로직이 필요합니다.

- 로그아웃, ID찾기, PW 재설정 API

- 테스트코드가 좀 맘에 들지않아 추후 리팩터링이 필요해보입니다.

<br>

---


### 📋 커밋 전 체크리스트 (여기는 리뷰어분들이 체크해주세요)
- [x] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
