### PR TITLE
회원 TABLE 암호화, 회원 복호화 VIEW 추가.

### DIFF
--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -15,6 +15,9 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
+    #JPA보다 flyway 우선 실행
+    autoconfigure:
+      exclude: org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
 logging:
   file:

--- a/module-api/src/main/resources/db/migration/V1.0.5__insert_common_code_age_and_gender_and_create_table_auth.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.5__insert_common_code_age_and_gender_and_create_table_auth.sql
@@ -1,0 +1,24 @@
+-- 공통코드 성별, 연령대 추가
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(48, 'gender', 0, NULL, 10, true, NULL, '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(49, 'man', 48, 'gender', 1, true, '남성', '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(50, 'woman', 48, 'gender', 2, true, '여성', '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(52, 'age', 0, NULL, 11, true, '연령대', '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(53, '20s', 52, 'age', 1, true, '20대 이하', '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(54, '30s', 52, 'age', 2, true, '30대', '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(55, '40s', 52, 'age', 3, true, '40대', '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(56, '50s', 52, 'age', 4, true, '50대', '2024-01-10', 'admin', NULL, NULL);
+INSERT INTO public.common_code (code_no, code_name, upper_no, upper_name, sort_order, is_used, description, created_at, created_by, modified_at, modified_by) VALUES(57, '60s', 52, 'age', 5, true, '60대 이상', '2024-01-10', 'admin', NULL, NULL);
+
+-- 권한 테이블
+CREATE TABLE if not exists Auth (
+    auth_no	    int	NOT NULL,
+    member_no	int NULL,
+    jwt_token	varchar	NULL,
+    sns_token	varchar	NULL,
+    created_at  date NOT NULL,
+    created_by  varchar NOT NULL,
+    modified_at date NULL,
+    modified_by varchar NULL
+);
+CREATE SEQUENCE if not exists auth_auth_no_seq increment  by 50;
+alter sequence auth_auth_no_seq increment by 50;

--- a/module-api/src/main/resources/db/migration/V1.0.6__modify_member_encrypt_and_create_decrypt_member_view.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.6__modify_member_encrypt_and_create_decrypt_member_view.sql
@@ -1,0 +1,102 @@
+-- 회원 테이블 필드 변경
+ALTER TABLE member ALTER COLUMN email TYPE BYTEA USING email::bytea;
+ALTER TABLE member ALTER COLUMN password TYPE BYTEA USING password::bytea;
+
+
+-- AES 암호화를 위한 확장 모듈 설치
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+
+-- 테이블 복호화 함수
+CREATE OR REPLACE FUNCTION washpedia_member_decrypt() RETURNS TRIGGER AS $$
+BEGIN
+    -- 비밀번호 복호화
+    NEW.password := pgp_sym_decrypt(NEW.password, 'changeRequired');
+    -- 이메일 복호화
+    NEW.email := pgp_sym_decrypt(NEW.email, 'changeRequired');
+
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 테이블 복호화 트리거 insert, update 이벤트 후 member_view 업데이트
+CREATE TRIGGER washpedia_member_decrypt_trigger
+    AFTER INSERT OR UPDATE ON member
+                        FOR EACH ROW
+                        EXECUTE FUNCTION washpedia_member_decrypt();
+
+-- 복호화 뷰 생성, 업데이트
+CREATE OR REPLACE VIEW member_view AS
+SELECT
+    member_no,
+    id,
+    encode(pgp_sym_decrypt(password, 'changeRequired')::bytea, 'escape') as password,
+    encode(pgp_sym_decrypt(email, 'changeRequired')::bytea, 'escape') as email,
+    gender,
+    birthdate,
+    created_at,
+    created_by,
+    modified_at,
+    modified_by
+FROM member;
+
+
+-- 뷰 insert 함수
+CREATE OR REPLACE FUNCTION member_view_insert_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+INSERT INTO member (member_no, id, "password", email, gender, birthdate, created_at, created_by, modified_at, modified_by)
+VALUES (nextval('member_member_no_seq'::regclass), NEW.id, pgp_sym_encrypt(NEW.password::TEXT, 'changeRequired'), pgp_sym_encrypt(NEW.email::TEXT, 'changeRequired'), NEW.gender, NEW.birthdate, NEW.created_at, NEW.created_by, NEW.modified_at, NEW.modified_by);
+
+RETURN NEW;
+
+END;
+$$ LANGUAGE plpgsql;
+
+-- 뷰 insert 트리거
+CREATE TRIGGER member_view_insert_trigger
+    INSTEAD OF INSERT ON member_view
+    FOR EACH ROW EXECUTE FUNCTION member_view_insert_trigger();
+
+
+-- 뷰 update 함수
+CREATE OR REPLACE FUNCTION member_view_update_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+UPDATE member SET
+    id = NEW.id,
+    "password" = pgp_sym_encrypt(NEW.password::TEXT, 'changeRequired'),
+    email = pgp_sym_encrypt(NEW.email::TEXT, 'changeRequired'),
+    gender = NEW.gender,
+    birthdate = NEW.birthdate,
+    created_at = NEW.created_at,
+    created_by = NEW.created_by,
+    modified_at = NEW.modified_at,
+    modified_by = NEW.modified_by
+WHERE member_no = NEW.member_no;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 뷰 update 트리거
+CREATE TRIGGER member_view_update_trigger
+    INSTEAD OF UPDATE ON member_view
+    FOR EACH ROW EXECUTE FUNCTION member_view_update_trigger();
+
+
+-- 뷰 delete 함수
+CREATE OR REPLACE FUNCTION member_view_delete_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+DELETE FROM member WHERE id = OLD.id;
+RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 뷰 delete 트리거
+CREATE TRIGGER member_view_delete_trigger
+    INSTEAD OF DELETE ON member_view
+    FOR EACH ROW EXECUTE FUNCTION member_view_delete_trigger();
+
+-- 테이블 member 권한 회수 설정
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON member FROM wash_admin;

--- a/module-domain/src/main/java/com/kernel360/member/entity/Member.java
+++ b/module-domain/src/main/java/com/kernel360/member/entity/Member.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 
 @Getter
 @Entity
-@Table(name = "member")
+@Table(name = "member_view")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
     @Id


### PR DESCRIPTION
권한 Entity 및 DDL 추가
공통코드 성별, 연령대 DML 추가

## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
 - 회원 테이블 암호화 수행 및 복호화 뷰 추가 하였습니다.
 - 공통코드 성별 , 연령대 추가하였습니다.
 - 서버 실행시 flyway가 JPA보다 먼저 실행되도록 수정하였습니다.
<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - application-{환경}.xml에 아래와 같은 코드가 추가되었습니다.
  
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/7056df69-e96e-4640-95ed-4a76cef3cf70)

 - 이제 member 엔티티는 member 테이블이 아닌, member view를 바라봅니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/f8dff84e-1f85-4ec7-8fea-9e25e4d18b31)


 - sql 1.0.5 및 1.0.6이 추가되었습니다. 1.0.5는 공통코드 성별, 연령대 DML과 권한 테이블 DDL이 있습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/f9e918de-67a2-4642-8005-03c6730f3e4e)
 - 1.0.6은 암호화 복호화 관련 쿼리가 들어있습니다.
- pull 받으시고나면 1.0.6 파일에서 다음의 'changeRequired' 키워드 모두 저희가 jasypt에 쓰는 공유키로 replace 해주셔야 합니다.
- 배포시엔 git action 스크립트에서 sql파일 내용의 일부를 replace 하는 구문이 추가되어야 합니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/e2a74196-cb7e-4a44-8a2a-25cda950a3fb)


 - 특히 member테이블에 접근 하기 전, 아래의 DCL이 먼저 수행되어야 합니다.
 - POSTGRES에선 권한이 좀 까다로운데, 테이블 생성 후 member 테이블에 CRUD를 먼저 하였다면
    revoke로 권한을 회수하였어도 이미 실행 이력이 있어 의도와 다르게 CRUD가 지속적으로 수행되는 이슈가 있습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/bb609c6a-eb1a-42f3-a482-39cb7df9f397)

공식문서를 다 뜯어 보는게 아닌이상 정말 100% 정확한지는 모르겠지만 AI 두녀석에게 물어봤을때 동일한 답변입니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/fd6f2dc9-361e-404b-bcfb-e565f0cd0407)


<br>

pull 받으시고나서 정상 동작하는지 확인 부탁드립니다.
추가로, table 목록을 지운 후 부팅 할 경우 도커 또는 postgres 문제인지 간혹 flyway가 정상 수행되지 않는 이슈가 있어
중요한 데이터가 따로 없으시다면 도커에서 delete & run 다시 하시는게 환경면에서 깔끔합니다.


## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
 - 아이디 중복조회, 이메일 중복조회 API
<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes [#20]
