### PR TITLE
feature :: 회원가입시 아이디, 이메일 중복검사 확인

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -7,10 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -39,4 +36,18 @@ public class MemberController {
 
         return new ResponseEntity<>(memberInfo, HttpStatus.OK);
     }
+
+    @GetMapping("/duplicatedCheckId/{id}")
+    public boolean duplicatedCheckId (@PathVariable String id){
+
+        return memberService.duplicatedCheckId(id);
+    }
+
+    @GetMapping("/duplicatedCheckEmail/{email}")
+    public boolean duplicatedCheckEmail (@PathVariable String email){
+
+        return memberService.duplicatedCheckEmail(email);
+    }
+
+
 }

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -80,4 +80,15 @@ public class MemberService {
     }
 
 
+    public boolean duplicatedCheckId(String id) {
+        Member member = memberRepository.findOneById(id);
+
+        return member != null;
+    }
+
+    public boolean duplicatedCheckEmail(String email) {
+        Member member = memberRepository.findOneByEmail(email);
+
+        return member != null;
+    }
 }

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -1,62 +1,129 @@
-//package com.kernel360.member.controller;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.kernel360.member.dto.MemberDto;
-//import com.kernel360.member.service.MemberService;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.http.MediaType;
-//import org.springframework.test.web.servlet.MockMvc;
-//import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-//import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-//import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-//import org.springframework.web.context.WebApplicationContext;
-//import org.springframework.web.filter.CharacterEncodingFilter;
-//
-//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-//
-//
-//@WebMvcTest(MemberController.class)
-//class MemberControllerTest {
-//
-//    @Autowired
-//    private MockMvc mockMvc;
-//
-//    @Autowired
-//    private WebApplicationContext context;
-//
-//    @MockBean
-//    private MemberService memberService;
-//
-//
-//    @BeforeEach
-//    public void setup(){
-//        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-//                      .addFilter(new CharacterEncodingFilter("UTF-8",true))
-//                      .alwaysDo(print())
-//                      .build();
-//    }
-//
-//    @Test
-//    @DisplayName("회원가입요청")
-//    void 회원가입요청로직() throws Exception {
-//
-//        /** given 목데이터 세팅 **/
-//        MemberDto memberDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword");
-//
-//        ObjectMapper objectMapper = new ObjectMapper();
-//        String param = objectMapper.writeValueAsString(memberDto);
-//
-//        /** then **/
-//        mockMvc.perform(MockMvcRequestBuilders.post("/member/join") //이 다음 restful
-//                       .contentType(MediaType.APPLICATION_JSON)
-//                       .content(param))
-//           .andExpect(MockMvcResultMatchers.status().isCreated()) //기대 결과 상태값
-//           .andReturn();
-//    }
-//
-//}
+package com.kernel360.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kernel360.member.dto.MemberDto;
+import com.kernel360.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDate;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @MockBean
+    private MemberService memberService;
+
+
+    @BeforeEach
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                                      .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                                      .alwaysDo(print())
+                                      .build();
+    }
+
+    @Test
+    @DisplayName("회원가입요청")
+    void 회원가입요청() throws Exception {
+
+        /** given 목데이터 세팅 **/
+        MemberDto memberDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String param = objectMapper.writeValueAsString(memberDto);
+
+        /** then **/
+        mockMvc.perform(MockMvcRequestBuilders.post("/member/join") //이 다음 restful
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(param))
+                                              .andExpect(MockMvcResultMatchers.status().isCreated()) //기대 결과 상태값
+                                              .andReturn();
+    }
+
+    @Test
+    @DisplayName("아이디_비밀번호를_받아_로그인_성공시_200반환")
+    void 로그인() throws Exception {
+
+        MemberDto memberDto = MemberDto.of("testID", "testPassword");
+        MemberDto memberInfo = new MemberDto(1,
+                                            "test01",
+                                            "kernel360@kernel360.com",
+                                            "",
+                                            null,
+                                            null,
+                                            LocalDate.now(),
+                                            "test01",
+                                            null,
+                                            null,
+                                            "dummyToken"
+            );
+        ObjectMapper objectMapper = new ObjectMapper();
+        String param = objectMapper.writeValueAsString(memberDto);
+
+        given(memberService.login(memberDto)).willReturn(memberInfo);
+
+        /** then **/
+        mockMvc.perform(MockMvcRequestBuilders.post("/member/login")
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(param))
+                                              .andExpect(MockMvcResultMatchers.status().isOk())
+                                              .andReturn();
+
+    }
+
+    @Test
+    @DisplayName("회원가입시_아이디_중복_검사하여_결과_및_200반환")
+    void 회원가입_아이디_중복_검사() throws Exception {
+
+        /** given 목데이터 세팅 **/
+        String id = "test01";
+        String message = "This is a test message.";
+
+        /** then **/
+        mockMvc.perform(MockMvcRequestBuilders.get("/member/duplicatedCheckId/{id}", id)
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(message))
+                                              .andExpect(MockMvcResultMatchers.status().isOk())
+                                              .andReturn();
+    }
+
+    @Test
+    @DisplayName("회원가입시_이메일_중복_검사하여_결과_및_200반환")
+    void 회원가입_이메일_중복_검사() throws Exception {
+
+        /** given 목데이터 세팅 **/
+        String email = "kernel360@kernel360.com";
+        String message = "This is a test message.";
+
+        /** then **/
+        mockMvc.perform(MockMvcRequestBuilders.get("/member/duplicatedCheckEmail/{email}", email)
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(message))
+                                              .andExpect(MockMvcResultMatchers.status().isOk())
+                                              .andReturn();
+    }
+
+
+}

--- a/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
@@ -130,4 +130,84 @@ class MemberServiceTest {
         assertEquals("D8A90363565890A7BD5E3FF42CFFDE851C8B532C60756EBBB837560DB3A011A7".toLowerCase(), encryptToken);
     }
 
+    @Test
+    @DisplayName("회원가입시_아이디_중복_있으면_TRUE")
+    void 회원가입_아이디_중복_검사_있으면_TRUE(){
+
+        /** given **/
+        String id = "test01";
+        Member memberEntity = Member.of(51, "test01", null, null, null, null);
+
+        /** stub **/
+        when(memberRepository.findOneById(anyString())).thenReturn(memberEntity);
+
+        /** when **/
+        Member member = memberRepository.findOneById(id);
+        boolean result = member != null ? true : false;
+
+        /** then **/
+        verify(memberRepository).findOneById(id);
+        assertTrue(result,"중복있으면TRUE이다.");
+    }
+
+    @Test
+    @DisplayName("회원가입시_아이디_중복_없으면_FALSE")
+    void 회원가입_아이디_중복_검사_없으면_FALSE(){
+
+        /** given **/
+        String id = "test01";
+
+        /** stub **/
+        when(memberRepository.findOneById(anyString())).thenReturn(null);
+
+        /** when **/
+        Member member = memberRepository.findOneById(id);
+        boolean result = member != null ? true : false;
+
+        /** then **/
+        verify(memberRepository).findOneById(id);
+        assertFalse(result,"중복없으면FALSE이다.");
+    }
+
+    @Test
+    @DisplayName("회원가입시_이메일_중복_검사_있으면_TRUE")
+    void 회원가입_이메일_중복_있으면_TRUE(){
+
+        /** given **/
+        String email = "kernel360@kernel360.co.kr";
+        Member memberEntity = Member.of(51, "test01", "kernel360@kernel360.co.kr", null, null, null);
+
+        /** stub **/
+        when(memberRepository.findOneByEmail(anyString())).thenReturn(memberEntity);
+
+        /** when **/
+        Member member = memberRepository.findOneByEmail(email);
+
+        boolean result = member != null ? true : false;
+
+        /** then **/
+        verify(memberRepository).findOneByEmail(email);
+        assertTrue(result,"중복있으면TRUE이다.");
+    }
+
+    @Test
+    @DisplayName("회원가입시_이메일_중복_검사_없으면_FALSE")
+    void 회원가입_이메일_중복_없으면_FALSE(){
+
+        /** given **/
+        String email = "kernel360@kernel360.co.kr";
+
+        /** stub **/
+        when(memberRepository.findOneByEmail(anyString())).thenReturn(null);
+
+        /** when **/
+        Member member = memberRepository.findOneByEmail(email);
+
+        boolean result = member != null ? true : false;
+
+        /** then **/
+        verify(memberRepository).findOneByEmail(email);
+        assertFalse(result,"중복없으면FALSE이다.");
+    }
+
 }

--- a/module-domain/src/main/java/com/kernel360/member/repository/MemberRepository.java
+++ b/module-domain/src/main/java/com/kernel360/member/repository/MemberRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Id> {
 
     Member findOneByIdAndPassword(String id, String password);
+
+    Member findOneById(String id);
+
+    Member findOneByEmail(String email);
 }


### PR DESCRIPTION
테스트코드 작성 및 통과, 인수테스트 통과

## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
 - 회원가입시 중복 체크 기능을 개발합니다.
 - controller return 자료형을 boolean으로 하여 삼항연산자를 쓰지 않아도 되어 서비스 코드가 간결해졌습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/ba260144-1e2f-4ae4-bf21-096dc67c0fd6)

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  -  딱히 변경점은 없으며 신규 기능으로 추가되었습니다.

<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #21 
