### PR TITLE
fixed :: 컨트롤러 맵핑 ModelAttribute -> RequestBody 변경

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -18,7 +18,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
-    public ResponseEntity<String> joinMember(@ModelAttribute MemberDto joinRequestDto) {
+    public ResponseEntity<String> joinMember(@RequestBody MemberDto joinRequestDto) {
 
         try {
             memberService.joinMember(joinRequestDto);
@@ -30,7 +30,7 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<MemberDto> login(@ModelAttribute MemberDto loginDto) {
+    public ResponseEntity<MemberDto> login(@RequestBody MemberDto loginDto) {
 
         MemberDto memberInfo = memberService.login(loginDto);
 


### PR DESCRIPTION
## 💡 Motivation and Context
- 컨트롤러의 DTO 맵핑 전략을 ModelAttribute -> RequestBody로 변경하였습니다.

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - Controller에서 mapping 받을 때 ModelAttribute -> RequestBody로 변경하였습니다.
  - ModelAttribute는 form data 또는 querystring로 보냈을때 받는 방법이고, json으로 받을 땐 requestbody를 써야됩니다.
  - 다른분들께서도 API 개발시 저처럼 착오가 발생하지 않도록 주의 부탁드립니다.

<br>

## 🌟 More
- 이슈 항목 기반으로 선점하여 진행.

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #50 
