### PR TITLE
feature :: 특정 API 접근 검증, 토큰 검증 및 재발급 기능

### DIFF
--- a/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
@@ -1,0 +1,58 @@
+package com.kernel360.global.Interceptor;
+
+import com.kernel360.auth.entity.Auth;
+import com.kernel360.member.service.MemberService;
+import com.kernel360.utils.ConvertSHA256;
+import com.kernel360.utils.JWT;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Component
+@RequiredArgsConstructor
+public class AcceptInterceptor implements HandlerInterceptor {
+
+    private final JWT jwt;
+    private final MemberService memberService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+
+        String requestToken = request.getHeader("Authorization");
+
+        //토큰검증
+        Boolean validateToken = jwt.validateToken(requestToken);
+
+        //검증 된 토큰이라면 시간차를 구함
+        if(validateToken) {
+            long diffInMinutes = jwt.checkedTime(requestToken);
+            //시간차가 2분 이내라면 해싱값을 비교함.
+            if(diffInMinutes <= 2){
+                String encryptToken = ConvertSHA256.convertToSHA256(requestToken);
+                Auth storedAuthInfo = memberService.findOneAuthByJwt(encryptToken);
+
+                //해싱값 일치시 재발급
+                if(encryptToken.equals(storedAuthInfo)){
+                    memberService.modifyAuthJwt(storedAuthInfo, jwt.ownerId(requestToken));
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+                           ModelAndView modelAndView) throws Exception {
+        // 컨트롤러가 실행된 후에 수행되는 로직
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+        // 뷰 렌더링이 완료된 후에 수행되는 로직
+    }
+}

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
@@ -1,6 +1,5 @@
 package com.kernel360.global.Interceptor;
 
-import com.kernel360.global.Interceptor.AcceptInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
@@ -1,4 +1,4 @@
-package com.kernel360.global.filter;
+package com.kernel360.global.Interceptor;
 
 import com.kernel360.global.Interceptor.AcceptInterceptor;
 import lombok.RequiredArgsConstructor;

--- a/module-api/src/main/java/com/kernel360/global/code/AcceptInterceptorErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/global/code/AcceptInterceptorErrorCode.java
@@ -1,0 +1,33 @@
+package com.kernel360.global.code;
+
+import com.kernel360.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AcceptInterceptorErrorCode implements ErrorCode {
+
+    DOSE_NOT_EXIST_REQUEST_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AIEC001", "요청자의 토큰이 존재하지 않음."),
+    FAILED_VALID_REQUEST_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AIEC002", "요청자의 토큰이 유효하지 않음."),
+    FAILED_VALID_REQUEST_TOKEN_PERIOD(HttpStatus.BAD_REQUEST.value(), "AIEC003", "토큰 유효시간 조건이 충족되지 않음."),
+    FAILED_VALID_REQUEST_TOKEN_HASH(HttpStatus.BAD_REQUEST.value(), "AIEC004", "로그인시 발급한 토큰의 해시값과 불일치함.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/module-api/src/main/java/com/kernel360/global/filter/InterceptorConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/filter/InterceptorConfig.java
@@ -1,0 +1,21 @@
+package com.kernel360.global.filter;
+
+import com.kernel360.global.Interceptor.AcceptInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class InterceptorConfig implements WebMvcConfigurer {
+    private final AcceptInterceptor acceptInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(acceptInterceptor)
+                .addPathPatterns("/member");
+                //.excludePathPatterns("/public/**"); // 제외할 URL 패턴
+    }
+
+}

--- a/module-api/src/main/java/com/kernel360/global/filter/InterceptorConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/filter/InterceptorConfig.java
@@ -14,7 +14,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(acceptInterceptor)
-                .addPathPatterns("/member");
+                .addPathPatterns("/member/testJwt");
                 //.excludePathPatterns("/public/**"); // 제외할 URL 패턴
     }
 

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -40,13 +40,18 @@ public class MemberController {
     @GetMapping("/duplicatedCheckId/{id}")
     public boolean duplicatedCheckId (@PathVariable String id){
 
-        return memberService.duplicatedCheckId(id);
+        return memberService.idDuplicationCheck(id);
     }
 
     @GetMapping("/duplicatedCheckEmail/{email}")
     public boolean duplicatedCheckEmail (@PathVariable String email){
 
-        return memberService.duplicatedCheckEmail(email);
+        return memberService.emailDuplicationCheck(email);
+    }
+
+    @PostMapping("/testJwt")
+    public String testJwt (){
+        return "checked";
     }
 
 

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -61,7 +61,7 @@ public class MemberService {
         return MemberDto.login(memberEntity, token);
     }
 
-    protected Auth modifyAuthJwt(Auth modifyAuth, String encryptToken) {
+    public Auth modifyAuthJwt(Auth modifyAuth, String encryptToken) {
         modifyAuth.updateJwt(encryptToken);
 
         return modifyAuth;
@@ -90,5 +90,9 @@ public class MemberService {
         Member member = memberRepository.findOneByEmail(email);
 
         return member != null;
+    }
+
+    public Auth findOneAuthByJwt(String encryptToken){
+        return authRepository.findOneAuthByJwt(encryptToken);
     }
 }

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -82,20 +82,24 @@ public class MemberService {
         return Member.loginMember(loginDto.id(), encodePassword);
     }
     @Transactional(readOnly = true)
-    public boolean duplicatedCheckId(String id) {
+    public boolean idDuplicationCheck (String id) {
         Member member = memberRepository.findOneById(id);
 
         return member != null;
     }
 
     @Transactional(readOnly = true)
-    public boolean duplicatedCheckEmail(String email) {
+    public boolean emailDuplicationCheck (String email) {
         Member member = memberRepository.findOneByEmail(email);
 
         return member != null;
     }
 
     public Auth findOneAuthByJwt(String encryptToken){
-        return authRepository.findOneAuthByJwt(encryptToken);
+        return authRepository.findOneByJwtToken(encryptToken);
+    }
+
+    public void reissuanceJwt(Auth storedAuthInfo) {
+        authRepository.save(storedAuthInfo);
     }
 }

--- a/module-common/src/main/java/com/kernel360/utils/JWT.java
+++ b/module-common/src/main/java/com/kernel360/utils/JWT.java
@@ -6,6 +6,9 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 @Component
@@ -31,8 +34,21 @@ public class JWT {
         }
     }
 
-    public String extractUsername(String token) {
+    public Date extractTime(String token) {
         Claims claims = Jwts.parserBuilder().setSigningKey(SECRET_KEY).build().parseClaimsJws(token).getBody();
-        return claims.getSubject();
+        return claims.getExpiration();
     }
+
+    public String ownerId(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(SECRET_KEY).build().parseClaimsJws(token).getBody();
+        return claims.getId();
+    }
+
+    public long checkedTime(String requestToken) {
+        LocalDateTime requestTime = extractTime(requestToken).toInstant().atZone((ZoneId.systemDefault())).toLocalDateTime();
+        LocalDateTime timeNow = LocalDateTime.now();
+
+        return Duration.between(requestTime, timeNow).toMinutes();
+    }
+
 }

--- a/module-common/src/main/java/com/kernel360/utils/JWT.java
+++ b/module-common/src/main/java/com/kernel360/utils/JWT.java
@@ -3,6 +3,7 @@ package com.kernel360.utils;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.SneakyThrows;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -14,11 +15,14 @@ import java.util.Date;
 @Component
 public class JWT {
     private static final Key SECRET_KEY = Keys.secretKeyFor(io.jsonwebtoken.SignatureAlgorithm.HS256);
-    private static final long EXPIRATION_TIME = (long) 1000 * 60 * 15; //15분
+    //private static final long EXPIRATION_TIME = (long) 1000 * 60 * 15; //15분
 
+    private static final long EXPIRATION_TIME = (long) 1000 * 60 * 3; //테스트를 위해 3분으로 조정
+    
     public String generateToken(String entityId) {
         return Jwts.builder()
-                .setSubject(entityId)
+                .setIssuer("washpedia")
+                .setId(entityId)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .signWith(SECRET_KEY)
@@ -44,11 +48,12 @@ public class JWT {
         return claims.getId();
     }
 
+    @SneakyThrows
     public long checkedTime(String requestToken) {
         LocalDateTime requestTime = extractTime(requestToken).toInstant().atZone((ZoneId.systemDefault())).toLocalDateTime();
         LocalDateTime timeNow = LocalDateTime.now();
 
-        return Duration.between(requestTime, timeNow).toMinutes();
+        return Duration.between(timeNow, requestTime).toMinutes();
     }
 
 }

--- a/module-common/src/main/java/com/kernel360/utils/JWT.java
+++ b/module-common/src/main/java/com/kernel360/utils/JWT.java
@@ -48,7 +48,6 @@ public class JWT {
         return claims.getId();
     }
 
-    @SneakyThrows
     public long checkedTime(String requestToken) {
         LocalDateTime requestTime = extractTime(requestToken).toInstant().atZone((ZoneId.systemDefault())).toLocalDateTime();
         LocalDateTime timeNow = LocalDateTime.now();

--- a/module-domain/src/main/java/com/kernel360/auth/repository/AuthRepository.java
+++ b/module-domain/src/main/java/com/kernel360/auth/repository/AuthRepository.java
@@ -8,5 +8,5 @@ public interface AuthRepository extends JpaRepository <Auth, Id> {
 
     Auth findOneByMemberNo(Long memberNo);
 
-    Auth findOneAuthByJwt(String encryptToken);
+    Auth findOneByJwtToken(String jwtToken);
 }

--- a/module-domain/src/main/java/com/kernel360/auth/repository/AuthRepository.java
+++ b/module-domain/src/main/java/com/kernel360/auth/repository/AuthRepository.java
@@ -8,4 +8,5 @@ public interface AuthRepository extends JpaRepository <Auth, Id> {
 
     Auth findOneByMemberNo(Integer memberNo);
 
+    Auth findOneAuthByJwt(String encryptToken);
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`

<br>
- 각각의 기능을 별도로 올리는 것이 가장 이상적이나, 부득이한 관계로 서로가 연관되어 같이 올림을 말씀드립니다.
<br>
- 로그인 한 사용자만 접근 가능한 API 요청시 토큰 유무로 로그인 회원인지 검증하는 기능을 구현했습니다.
<br>
- 토큰의 대한 검증이 요청 왔을시 유효하면 재발급, 무효하면 에러코드를 보냅니다.
<br>
- 그외 저번 PR 내용을 반영하여 일부 내용을 아주 조금 수정하였습니다. 별도로 PR을 올리긴 애메하여 같이 올립니다.

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  <br>
- #21  PR 코드리뷰를 참고하여 맴버 도메인의 일부 컨트롤러 및 서비스 메서드의 이름을 변경하였습니다.
 
![스크린샷 2024-01-17 153911](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/2fde669c-6b02-499c-b0e0-dd99f45ae0db)

![스크린샷 2024-01-17 153944](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/fb84702f-1b5a-4391-9f26-7fd8a6fb2e40)


 - 특정 URI 호출에 따라 접근을 허용할지 판단하는 인터셉터가  추가되었습니다.
   1) IntercepterConfig에 인터셉터를 적용할지 말지 설정을 할 수 있습니다.
![스크린샷 2024-01-17 155109](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/b653639a-8b08-4daa-a1ac-aea60f41234f)

2)  AcceptInterceptor의 perHandle에서 특정 컨트롤러에 접근 전 어떤일을 할지 명세하였습니다. 여기선 JWT를 이용하여 토큰 검증을 수행하며, 다음의 과정에 따라 적절한 응답을 수행합니다. 
Early return 패턴(?)을 적용하였으며, 순차적으로 실패 조건이 발생하면 exception을 발생시켜 return false를 보냅니다.
명시적으로 false를 대입하지 않아도 exception 자체가 false 효과가 있습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/05a62811-2a8a-4e18-96ac-a3a9cf8673d6)

테스트 실패 시나리오 (요청 -> 리턴)
1. 토큰이 없는가 ? -> 토큰 누락으로 존재 하지 않음 return
2. 토큰은 있지만  JWT의 유효성 검사를 통과하지 못하였는가 ? -> 토큰이 유효하지 않음 return
3. 재발급 조건 충족시 요청자 토큰 해싱값으로 로그인시 발급한 토큰 해싱값을 조회 할 수 없는가? -> 토큰값 불일치 return
4. 로그인시 발급한 토큰 해싱값을 찾았으나, 요청자의 토큰 해싱값과 불일치 하는가? -> 토큰값 불일치 return

3의 경우 토큰의 유효시간은 있으나 갱신 된 최신의 토큰 요청이 아님으로 발생하는 에러이며, 정상적인 비즈니스 로직에선 발생 할 수 없는 상황입니다.
4의 경우 요청자의 토큰 값이 탈취당하여 변조가 발생했다면 불일치함을 나타내는 상황입니다.

- 인터셉터에서 사용하는 에러 코드를 명세하였습니다.
- API테스트시 return 받는 결과를 보았을 때 별도로 분리하는 것이 빠른 판단에 좋을 것이라 생각되었는데 이 부분에 대해선 다른분들 의견을 듣고 맞추도록 하겠습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/626930c2-b68a-47bb-b1a9-e70882c3eafb)

Request
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/20529e87-2ca6-4a32-b6e2-0f613598facf)

Response
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/39f5d0dc-0b1c-4749-a446-57b99964ab69)
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/0a800d2e-acb4-4fc9-9e10-eae4d5b6f7d9)


참고로 Early return 패턴은 다음과 같은 다른 이름으로도 부른다고 합니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/337430ac-4eed-4182-ab41-007443d475df)


## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>
- 인터셉터 테스트코드 (가능...한가?)
<br>
- 프론트엔드 개발자와 협의 후 로직 조정 (https://washpedia.slack.com/archives/C06DKGK5006/p1705458828971939)

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #47 #48
