### PR TITLE
Feature :: 위해우려제품 목록 정보를 초록누리에서 읽어와서 저장하기

### DIFF
--- a/module-api/src/main/resources/db/migration/V1.1.3__create_concerned_product_table.sql
+++ b/module-api/src/main/resources/db/migration/V1.1.3__create_concerned_product_table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE if not exists ConcernedProduct
+(
+    prdt_no                    VARCHAR(255) PRIMARY KEY,
+    prdt_name                  VARCHAR(255) NOT NULL,
+    slfsfcfst_no               VARCHAR(255) NOT NULL,
+    item                       VARCHAR(255) NOT NULL,
+    comp_nm                    VARCHAR(255) NOT NULL,
+    inspected_organization     VARCHAR(255),
+    issued_date                DATE,
+    upper_item                 VARCHAR(255),
+    product_type               VARCHAR(255),
+    renewed_type               VARCHAR(255),
+    safety_inspection_standard TEXT,
+    kid_protect_package        VARCHAR(255),
+    manufacture_nation         VARCHAR(255),
+    product_definition         VARCHAR(255),
+    manufacture                TEXT,
+    created_at                 DATE         NOT NULL DEFAULT CURRENT_DATE,
+    created_by                 VARCHAR(255) NOT NULL DEFAULT 'admin',
+    modified_at                DATE,
+    modified_by                VARCHAR(255)
+);

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductListClient.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductListClient.java
@@ -31,7 +31,7 @@ public class ConcernedProductListClient {
                          .retrieve()
                          .onStatus(HttpStatusCode::is4xxClientError,
                                  ((request, response) -> {
-                                     log.debug("[ERROR] :: 4XX 에러 발생"
+                                     log.error("[ERROR] :: 4XX 에러 발생"
                                              + response.getStatusText());
                                      throw new RuntimeException(
                                              response.getStatusCode()
@@ -40,7 +40,7 @@ public class ConcernedProductListClient {
                                  }))
                          .onStatus(HttpStatusCode::is5xxServerError,
                                  (request, response) -> {
-                                     log.debug("[ERROR] :: 5XX 에러 발생"
+                                     log.error("[ERROR] :: 5XX 에러 발생"
                                              + response.getStatusText());
                                      throw new RuntimeException(
                                              response.getStatusCode()

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductListClient.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductListClient.java
@@ -1,0 +1,68 @@
+package com.kernel360.modulebatch.concernedproduct.client;
+
+import com.kernel360.brand.entity.Brand;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class ConcernedProductListClient {
+
+    @Value("${external.ecolife-api.path}")
+    private String BASE_PATH;
+
+    @Value("${external.ecolife-api.service-key}")
+    private String AUTH_KEY;
+    private final RestClient restClient;
+    public ConcernedProductListClient() {
+        this.restClient = RestClient.builder()
+                                    .build();
+    }
+    public String getXmlResponse(Brand brand, Long pageNumber) {
+        return restClient.post().uri(buildUri(brand, pageNumber))
+                         .accept(MediaType.APPLICATION_XML)
+                         .acceptCharset(StandardCharsets.UTF_8)
+                         .retrieve()
+                         .onStatus(HttpStatusCode::is4xxClientError,
+                                 ((request, response) -> {
+                                     log.debug("[ERROR] :: 4XX 에러 발생"
+                                             + response.getStatusText());
+                                     throw new RuntimeException(
+                                             response.getStatusCode()
+                                                     + response.getHeaders()
+                                                               .toString());
+                                 }))
+                         .onStatus(HttpStatusCode::is5xxServerError,
+                                 (request, response) -> {
+                                     log.debug("[ERROR] :: 5XX 에러 발생"
+                                             + response.getStatusText());
+                                     throw new RuntimeException(
+                                             response.getStatusCode()
+                                                     + response.getHeaders()
+                                                               .toString());
+                                 })
+                         .onStatus(HttpStatusCode::is2xxSuccessful,
+                                 ((request, response) -> log.info("[INFO] :: api 요청 성공"
+                                         + response.getBody())))
+                         .body(String.class);
+    }
+
+    public String buildUri(Brand brand, Long pageNumber) {
+
+        return UriComponentsBuilder.fromHttpUrl(BASE_PATH)
+                                   .queryParam("AuthKey", AUTH_KEY)
+                                   .queryParam("ServiceName", "slfsfcfst01List")
+                                   .queryParam("PageCount", "20")
+                                   .queryParam("PageNum", String.valueOf(pageNumber))
+                                   .queryParam("compNm", brand.getCompanyName())
+                                   .build()
+                                   .toUriString();
+    }
+}
+

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
@@ -9,10 +9,10 @@ import java.time.LocalDate;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JacksonXmlRootElement(localName = "row")
 public record ConcernedProductDetailDto(
+        @JacksonXmlProperty(localName = "prdt_no")
+        String productNo,
         @JacksonXmlProperty(localName = "prdt_nm")
         String productName,
-        @JacksonXmlProperty(localName = "prdt_no")
-        String productMasterId,
         @JacksonXmlProperty(localName = "inspct_org")
         String inspectedOrganization,
         @JacksonXmlProperty(localName = "issu_date")

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
@@ -11,35 +11,50 @@ import java.time.LocalDate;
 public record ConcernedProductDetailDto(
         @JacksonXmlProperty(localName = "prdt_no")
         String productNo,
+
         @JacksonXmlProperty(localName = "prdt_nm")
         String productName,
+
         @JacksonXmlProperty(localName = "inspct_org")
         String inspectedOrganization,
+
         @JacksonXmlProperty(localName = "issu_date")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate issuedDate,
+
         @JacksonXmlProperty(localName = "upper_item")
         String upperItem,
+
         @JacksonXmlProperty(localName = "prdt_type")
         String productType,
+
         @JacksonXmlProperty(localName = "renew_yn")
         String renewedType,
+
         @JacksonXmlProperty(localName = "slfsfcfst_no")
         String reportNumber,
+
         @JacksonXmlProperty(localName = "safe_sd")
         String safetyInspectionStandard,
+
         @JacksonXmlProperty(localName = "kid_prt_pkg")
         String kidProtectPackage,
+
         @JacksonXmlProperty(localName = "mf_cpy")
         String manufactureNation,
+
         @JacksonXmlProperty(localName = "df")
         String productDefinition,
+
         @JacksonXmlProperty(localName = "item")
         String item,
+
         @JacksonXmlProperty(localName = "mf_icm")
         String manufacture,
+
         @JacksonXmlProperty(localName = "comp_nm")
-        String companyName) {
+        String companyName
+) {
     public static ConcernedProductDetailDto of(
             String productName,
             String productMasterId,

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
@@ -1,0 +1,64 @@
+package com.kernel360.modulebatch.concernedproduct.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "row")
+public record ConcernedProductDetailDto(
+        @JacksonXmlProperty(localName = "prdt_nm")
+        String productName,
+        @JacksonXmlProperty(localName = "prdt_no")
+        String productMasterId,
+        @JacksonXmlProperty(localName = "inspct_org")
+        String inspectedOrganization,
+        @JacksonXmlProperty(localName = "issu_date")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate issuedDate,
+        @JacksonXmlProperty(localName = "upper_item")
+        String upperItem,
+        @JacksonXmlProperty(localName = "prdt_type")
+        String productType,
+        @JacksonXmlProperty(localName = "renew_yn")
+        String renewedType,
+        @JacksonXmlProperty(localName = "slfsfcfst_no")
+        String reportNumber,
+        @JacksonXmlProperty(localName = "safe_sd")
+        String safetyInspectionStandard,
+        @JacksonXmlProperty(localName = "kid_prt_pkg")
+        String kidProtectPackage,
+        @JacksonXmlProperty(localName = "mf_cpy")
+        String manufactureNation,
+        @JacksonXmlProperty(localName = "df")
+        String productDefinition,
+        @JacksonXmlProperty(localName = "item")
+        String item,
+        @JacksonXmlProperty(localName = "mf_icm")
+        String manufacture,
+        @JacksonXmlProperty(localName = "comp_nm")
+        String companyName) {
+    public static ConcernedProductDetailDto of(
+            String productName,
+            String productMasterId,
+            String inspectedOrganization,
+            LocalDate issuedDate,
+            String upperItem,
+            String productType,
+            String renewedType,
+            String reportNumber,
+            String safetyInspectionStandard,
+            String kidProtectPackage,
+            String manufactureNation,
+            String productDefinition,
+            String item,
+            String manufacture,
+            String companyName) {
+        return new ConcernedProductDetailDto(productName, productMasterId, inspectedOrganization, issuedDate,
+                upperItem, productType, renewedType, reportNumber, safetyInspectionStandard, kidProtectPackage,
+                manufactureNation, productDefinition, item, manufacture, companyName);
+    }
+
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailListDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailListDto.java
@@ -1,0 +1,26 @@
+package com.kernel360.modulebatch.concernedproduct.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.List;
+@JacksonXmlRootElement(localName = "rowList")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ConcernedProductDetailListDto(
+        @JacksonXmlProperty(localName = "count")
+        int count,
+
+        @JacksonXmlProperty(localName = "resultcode")
+        String resultCode,
+
+        @JacksonXmlProperty(localName = "pagenum")
+        int pageNum,
+
+        @JacksonXmlProperty(localName = "pagesize")
+        int pageSize,
+
+        @JacksonXmlProperty(localName = "row")
+        @JacksonXmlElementWrapper(useWrapping = false)
+        List<ConcernedProductDetailDto> concernedProductDetailDtoList) {
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
@@ -3,13 +3,19 @@ package com.kernel360.modulebatch.concernedproduct.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.kernel360.ecolife.entity.ConcernedProduct;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JacksonXmlRootElement(localName = "row")
 public record ConcernedProductDto(
-        @JacksonXmlProperty(localName = "productName") String productName,
-        @JacksonXmlProperty(localName = "productNumber") String productNumber,
-        @JacksonXmlProperty(localName = "reportNumber") String reportNumber,
+        @JacksonXmlProperty(localName = "prdt_no") String productNo,
+        @JacksonXmlProperty(localName = "prdt_nm") String productName,
+        @JacksonXmlProperty(localName = "slfsfcfst_no") String reportNumber,
         @JacksonXmlProperty(localName = "item") String item,
-        @JacksonXmlProperty(localName = "comp_nm") String comp_nm) {
+        @JacksonXmlProperty(localName = "comp_nm") String companyName) {
+
+    public static ConcernedProduct toEntity(ConcernedProductDto dto) {
+        return ConcernedProduct.of(dto.productNo, dto.productName(),
+                dto.reportNumber(), dto.item(), dto.companyName());
+    }
 }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
@@ -9,10 +9,15 @@ import com.kernel360.ecolife.entity.ConcernedProduct;
 @JacksonXmlRootElement(localName = "row")
 public record ConcernedProductDto(
         @JacksonXmlProperty(localName = "prdt_no") String productNo,
+
         @JacksonXmlProperty(localName = "prdt_nm") String productName,
+
         @JacksonXmlProperty(localName = "slfsfcfst_no") String reportNumber,
+
         @JacksonXmlProperty(localName = "item") String item,
-        @JacksonXmlProperty(localName = "comp_nm") String companyName) {
+
+        @JacksonXmlProperty(localName = "comp_nm") String companyName
+) {
 
     public static ConcernedProduct toEntity(ConcernedProductDto dto) {
         return ConcernedProduct.of(dto.productNo, dto.productName(),

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
@@ -1,0 +1,15 @@
+package com.kernel360.modulebatch.concernedproduct.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "row")
+public record ConcernedProductDto(
+        @JacksonXmlProperty(localName = "productName") String productName,
+        @JacksonXmlProperty(localName = "productNumber") String productNumber,
+        @JacksonXmlProperty(localName = "reportNumber") String reportNumber,
+        @JacksonXmlProperty(localName = "item") String item,
+        @JacksonXmlProperty(localName = "comp_nm") String comp_nm) {
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductListDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductListDto.java
@@ -1,0 +1,30 @@
+package com.kernel360.modulebatch.concernedproduct.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.List;
+
+@JacksonXmlRootElement(localName = "rowList")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ConcernedProductListDto(
+        @JacksonXmlProperty(localName = "count")
+        int count,
+
+        @JacksonXmlProperty(localName = "resultcode")
+        String resultCode,
+
+        @JacksonXmlProperty(localName = "pagenum")
+        int pageNum,
+
+        @JacksonXmlProperty(localName = "pagesize")
+        int pageSize,
+
+        @JacksonXmlProperty(localName = "row")
+        @JacksonXmlElementWrapper(useWrapping = false)
+        List<ConcernedProductDto> concernedProductDtoList)
+{
+}
+
+

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/core/FetchConcernedProductListFromBrandJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/core/FetchConcernedProductListFromBrandJobConfig.java
@@ -1,0 +1,82 @@
+package com.kernel360.modulebatch.concernedproduct.job.core;
+
+import com.kernel360.brand.entity.Brand;
+import com.kernel360.modulebatch.concernedproduct.client.ConcernedProductListClient;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductDto;
+import com.kernel360.modulebatch.concernedproduct.job.infra.ConcernedProductListItemProcessor;
+import com.kernel360.modulebatch.concernedproduct.job.infra.ConcernedProductListItemWriter;
+import com.kernel360.modulebatch.concernedproduct.service.ConcernedProductService;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FetchConcernedProductListFromBrandJobConfig {
+    private final ConcernedProductListClient client;
+    private final ConcernedProductService service;
+    private final EntityManagerFactory emf;
+
+
+    @Bean
+    public Job fetchConcernedProductListFromBrandJob(JobRepository jobRepository,
+                                            @Qualifier("fetchConcernedProductListFromBrandStep") Step fetchConcernedProductListStep) {
+
+        return new JobBuilder("fetchConcernedProductListFromBrandJob", jobRepository)
+                .start(fetchConcernedProductListStep)
+                .build();
+    }
+
+
+    //-- List Step --//
+    @Bean
+    public Step fetchConcernedProductListFromBrandStep(JobRepository jobRepository,
+                                              PlatformTransactionManager transactionManager) throws Exception {
+
+        return new StepBuilder("fetchConcernedProductListFromBrandStep", jobRepository)
+                .<Brand, List<ConcernedProductDto>>chunk(1, transactionManager)
+                .reader(readBrandForConcernedProduct())
+                .processor(concernedProductListItemProcessor())
+                .writer(concernedProductListItemWriter())
+                .build();
+    }
+
+
+    @Bean
+    @StepScope
+    @Qualifier("readBrandForConcernedProduct")
+    public JpaPagingItemReader<Brand> readBrandForConcernedProduct() throws Exception {
+        JpaPagingItemReader<Brand> jpaPagingItemReader = new JpaPagingItemReader<>();
+        jpaPagingItemReader.setEntityManagerFactory(emf);
+        jpaPagingItemReader.setQueryString("SELECT b FROM Brand b");
+        jpaPagingItemReader.afterPropertiesSet();
+
+        return jpaPagingItemReader;
+    }
+
+    @Bean
+    @StepScope
+    public ConcernedProductListItemProcessor concernedProductListItemProcessor() {
+        return new ConcernedProductListItemProcessor(client, service);
+    }
+
+    @Bean
+    @StepScope
+    public ConcernedProductListItemWriter concernedProductListItemWriter() {
+        return new ConcernedProductListItemWriter(service);
+    }
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemProcessor.java
@@ -1,0 +1,48 @@
+package com.kernel360.modulebatch.concernedproduct.job.infra;
+
+import com.kernel360.brand.entity.Brand;
+import com.kernel360.modulebatch.concernedproduct.client.ConcernedProductListClient;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductDto;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductListDto;
+import com.kernel360.modulebatch.concernedproduct.service.ConcernedProductService;
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ConcernedProductListItemProcessor implements ItemProcessor<Brand, List<ConcernedProductDto>> {
+    private final ConcernedProductListClient client;
+    private final ConcernedProductService service;
+
+    @Override
+    public List<ConcernedProductDto> process(@Nonnull Brand brand) throws Exception {
+        List<ConcernedProductDto> list = new ArrayList<>();
+        long nextPage = -1;
+
+        int maxPageNumber;
+        do {
+            nextPage++;
+            String xmlResponse = fetchXmlResponse(brand, nextPage);
+
+            maxPageNumber = service.getTotalPageCount(xmlResponse);
+            ConcernedProductListDto concernedProductListDto = service.deserializeXml2ListDto(xmlResponse);
+            if (concernedProductListDto.count() == 0 || concernedProductListDto.concernedProductDtoList() == null) {
+                break;
+            }
+            list.addAll(concernedProductListDto.concernedProductDtoList());
+        } while (nextPage < maxPageNumber);
+
+        return list;
+    }
+
+    private String fetchXmlResponse(Brand brand, long nextPage) {
+        log.info("Fetch Page = {}", nextPage);
+        String xmlResponse = client.getXmlResponse(brand, nextPage);
+        log.info("Response accepted : {}", xmlResponse);
+        return xmlResponse;
+    }
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemWriter.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemWriter.java
@@ -1,0 +1,23 @@
+package com.kernel360.modulebatch.concernedproduct.job.infra;
+
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductDto;
+import com.kernel360.modulebatch.concernedproduct.service.ConcernedProductService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+@RequiredArgsConstructor
+public class ConcernedProductListItemWriter implements ItemWriter<List<ConcernedProductDto>> {
+
+    private final ConcernedProductService service;
+
+    @Override
+    public void write(Chunk<? extends List<ConcernedProductDto>> chunk) throws Exception {
+        for (List<ConcernedProductDto> list : chunk) {
+            for (ConcernedProductDto dto : list) {
+                service.saveConcernedProduct(dto);
+            }
+        }
+    }
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/service/ConcernedProductService.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/service/ConcernedProductService.java
@@ -1,0 +1,51 @@
+package com.kernel360.modulebatch.concernedproduct.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.kernel360.ecolife.entity.ConcernedProduct;
+import com.kernel360.ecolife.repository.ConcernedProductRepository;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductDetailListDto;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductDto;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductListDto;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@ComponentScan("com.kernel360.ecolife")
+@RequiredArgsConstructor
+public class ConcernedProductService {
+    private final ConcernedProductRepository concernedProductRepository;
+    private final XmlMapper xmlMapper = new XmlMapper();
+
+    public ConcernedProductListDto deserializeXml2ListDto(String xml) throws JsonProcessingException {
+        return xmlMapper.readValue(xml, ConcernedProductListDto.class);
+    }
+
+    public ConcernedProductDetailListDto deserializeXml2DetailDto(String xml) throws JsonProcessingException {
+        return xmlMapper.readValue(xml, ConcernedProductDetailListDto.class);
+    }
+
+    public int getTotalPageCount(String response) throws JsonProcessingException {
+        return deserializeXml2ListDto(response).count() / 20 + 1;
+    }
+
+    @Transactional
+    public void saveConcernedProduct(ConcernedProductDto dto) throws JobExecutionException {
+        ConcernedProduct concernedProduct = ConcernedProductDto.toEntity(dto);
+        Optional<ConcernedProduct> foundConcernedProduct = concernedProductRepository.findById(dto.productNo());
+
+        if (foundConcernedProduct.isEmpty()) {
+            ConcernedProduct newConcernedProduct = concernedProductRepository.save(concernedProduct);
+            log.info("Saved entity : {} ", newConcernedProduct.getProductName());
+            return;
+        }
+        log.info("Existing entity found: {}. Continuing without save", concernedProduct.getProductName());
+
+    }
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/dto/ReportedProductDetailDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/dto/ReportedProductDetailDto.java
@@ -59,7 +59,7 @@ public record ReportedProductDetailDto(
         @JacksonXmlProperty(localName = "sum3")
         String allergicSubstance,
         @JacksonXmlProperty(localName = "sum4")
-        String Surfactant,
+        String surfactant,
         @JacksonXmlProperty(localName = "sum5")
         String otherSubstance,
         @JacksonXmlProperty(localName = "sum6")
@@ -105,7 +105,7 @@ public record ReportedProductDetailDto(
                 detailDto.useMethod,
                 detailDto.usageAttentionReport, detailDto.firstAid, detailDto.mainSubstance, detailDto.preservative,
                 detailDto.allergicSubstance,
-                detailDto.Surfactant, detailDto.otherSubstance, detailDto.FluorescentWhiteningAgent,
+                detailDto.surfactant, detailDto.otherSubstance, detailDto.FluorescentWhiteningAgent,
                 detailDto.manufacture, detailDto.manufactureMethod,
                 detailDto.manufactureNation, detailDto.companyAddress, detailDto.companyTel,
                 detailDto.importedCompanyName, detailDto.importedCompanyAddress,

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/dto/ReportedProductDetailListDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/dto/ReportedProductDetailListDto.java
@@ -5,12 +5,13 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 
-public record ReportedProductDetailListDto(@JsonProperty("count") int count,
-                                           @JsonProperty("resultcode") String resultCode,
-                                           @JsonProperty("pagenum") int pageNum,
-                                           @JsonProperty("pagesize") int pageSize,
-                                           @JacksonXmlElementWrapper(useWrapping = false)
-                                           @JacksonXmlProperty(localName = "row")
-                                           List<ReportedProductDetailDto> reportedProductDetailDtoList) {
+public record ReportedProductDetailListDto(
+        @JsonProperty("count") int count,
+        @JsonProperty("resultcode") String resultCode,
+        @JsonProperty("pagenum") int pageNum,
+        @JsonProperty("pagesize") int pageSize,
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JacksonXmlProperty(localName = "row")
+        List<ReportedProductDetailDto> reportedProductDetailDtoList) {
 
 }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
@@ -1,0 +1,49 @@
+package com.kernel360.modulebatch.scheduler;
+
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile({"local", "prod"})
+public class ConcernedProductScheduler {
+    private final Job fetchConcernedProductListFromBrandJob;
+    private final JobLauncher jobLauncher;
+
+    @Autowired
+    public ConcernedProductScheduler(
+            @Qualifier("fetchConcernedProductListFromBrandJob") Job fetchConcernedProductListJob,
+            JobLauncher jobLauncher) {
+
+        this.fetchConcernedProductListFromBrandJob = fetchConcernedProductListJob;
+        this.jobLauncher = jobLauncher;
+    }
+
+    @Scheduled(cron = "0 30 11,13 * * TUE", zone = "Asia/Seoul")
+    public void executeFetchConcernedProductListJob() {
+        executeJob(fetchConcernedProductListFromBrandJob);
+    }
+
+    private synchronized void executeJob(Job job) {
+
+        try {
+            jobLauncher.run(
+                    job,
+                    new JobParametersBuilder()
+                            .addString("DATETIME", LocalDateTime.now().toString())
+                            .toJobParameters()
+            );
+        } catch (JobExecutionException je) {
+            log.error("JobExecutionException Occurred", je);
+        }
+    }
+}

--- a/module-batch/src/main/resources/application-local.yml
+++ b/module-batch/src/main/resources/application-local.yml
@@ -25,6 +25,11 @@ spring:
       validation-timeout: 5000
       minimum-idle: 5
 
+external:
+  ecolife-api:
+    path: ENC(HJqiuwP4Iq/lc0Furr8PuwJpi07wqbRey6GxynTWONBeBI1AZc6GACvq/nKi9K1T6OHzr7Cw7VO3rD/SACeQ4w==)
+    service-key: ENC(ZPvWVqCPl2z8+967U8+BdPdcy9orRW8AEW6AgdM4TO+KuWRw5ziDJ0Dr3omhh2BGVVJQGpdOxEU=)
+
 
 logging:
   file:

--- a/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProduct.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProduct.java
@@ -5,12 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @Table(name = "concerned_product")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ConcernedProduct {
     @Id
@@ -29,4 +31,8 @@ public class ConcernedProduct {
     @Column(name = "comp_nm")
     private String companyName;
 
+    public static ConcernedProduct of(String productNo, String productName, String reportNumber, String item,
+                                      String companyName) {
+        return new ConcernedProduct(productNo, productName, reportNumber, item, companyName);
+    }
 }

--- a/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProduct.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProduct.java
@@ -1,0 +1,32 @@
+package com.kernel360.ecolife.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "concerned_product")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConcernedProduct {
+    @Id
+    @Column(name = "prdt_no", nullable = false)
+    private String productNo;
+
+    @Column(name = "prdt_name", nullable = false)
+    private String productName;
+
+    @Column(name = "slfsfcfst_no")
+    private String reportNumber;
+
+    @Column(name = "item")
+    private String item;
+
+    @Column(name = "comp_nm")
+    private String companyName;
+
+}

--- a/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProductDetail.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProductDetail.java
@@ -1,0 +1,47 @@
+package com.kernel360.ecolife.entity;
+
+import com.kernel360.base.BaseRawEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@MappedSuperclass
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConcernedProductDetail extends BaseRawEntity {
+
+    @Column(name = "inspected_organization")
+    private String inspectedOrganization;
+
+    @Column(name = "issued_date")
+    private LocalDate issuedDate;
+
+    @Column(name = "upper_item")
+    private String upperItem;
+
+    @Column(name = "product_type")
+    private String productType;
+
+    @Column(name = "renewed_type")
+    private String renewedType;
+
+    @Column(name = "safety_inspection_standard", length = Integer.MAX_VALUE)
+    private String safetyInspectionStandard;
+
+    @Column(name = "kid_protect_package")
+    private String kidProtectPackage;
+
+    @Column(name = "manufacture_nation")
+    private String manufactureNation;
+
+    @Column(name = "product_definition", length = Integer.MAX_VALUE)
+    private String productDefinition;
+
+    @Column(name = "manufacture")
+    private String manufacture;
+}

--- a/module-domain/src/main/java/com/kernel360/ecolife/entity/ReportedProduct.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/entity/ReportedProduct.java
@@ -3,6 +3,7 @@ package com.kernel360.ecolife.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(name = "reported_product")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReportedProduct extends ReportedProductDetails {
 

--- a/module-domain/src/main/java/com/kernel360/ecolife/repository/ConcernedProductRepository.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/repository/ConcernedProductRepository.java
@@ -1,0 +1,7 @@
+package com.kernel360.ecolife.repository;
+
+import com.kernel360.ecolife.entity.ConcernedProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConcernedProductRepository extends JpaRepository<ConcernedProduct,String> {
+}


### PR DESCRIPTION
## 💡 Motivation and Context
`위해우려제품 목록 정보를 초록누리에서 읽어와서 저장함으로서, safetystatus가 서로 다른 제품정보를 Product 테이블에 저장할 수 있도록 하여야 합니다.`

<br>

## 🔨 Modified
> 위해우려제품 목록 정보를 초록누리에서 읽어와서 저장합니다.
  - ![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/6c2dbf5d-a52f-44bf-a963-cf59f93cb548)
  - concerned_product 테이블을 추가하였습니다. (V1.1.3__create_concerned_product_table.sql)

<br>

## 🌟 More
- _목록 정보를 바탕으로 세부정보를 읽어오고, 세부정보까지 로드된 제품들을 Product 테이블로 옮겨야 합니다._

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #88
