### PR TITLE
chore :: docker-compose를 쓰지 않고 수동배포

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,15 +1,8 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle and Docker for WashPedia Project
+name: Java CI with Gradle WashPedia Project
 
 on:
   push:
-    branches: [ "feature/docker" ]
+    branches: [ "send_develop_server" ]
 
 permissions:
   contents: read
@@ -20,81 +13,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      ## jdk setting
       - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
-      ## application.yml 생성 후 secret 값 복붙
 
-      # Gradle Build를 위한 권한 부여
+      - name: Replace SQL Queries
+        run: |
+          sql_directory="./module-api/src/main/resources/db/migration"
+          old_text="changeRequired"
+          new_text="${{ secrets.PUBLIC_KEY }}"
+          find "$sql_directory" -type f -name "*.sql" -exec sed -i "s|$old_text|$new_text|g" {} +
+
       - name: Grant execute permission for gradlew
         working-directory: ./module-api
         run: chmod +x ./gradlew
 
-      # Gradle Build (test 제외)
       - name: Build with Gradle
         working-directory: ./module-api
-        run: ./gradlew clean build -x test
+        run: ./gradlew build
 
-      # Gradle Build를 위한 권한 부여
-      - name: Grant execute permission for gradlew
-        working-directory: ./module-batch
-        run: chmod +x ./gradlew
+      - name: Install sshpass
+        run: sudo apt-get install -y sshpass
 
-      # Gradle Build (test 제외)
-      - name: Build with Gradle
-        working-directory: ./module-batch
-        run: ./gradlew clean build -x test
+      - name: Copy JAR file to remote server using SCP
+        run: |
+          cd module-api/build/libs/
+          export PASSWORD="${{ secrets.VULTR_PW }}"
+          sshpass -p "$PASSWORD" scp -o StrictHostKeyChecking=no -P 22 module-api-0.0.1-SNAPSHOT.jar ${{ secrets.VULTR_USER_NAME }}@${{ secrets.VULTR_IP }}:/root
 
-      # DockerHub 로그인
-      - name: DockerHub Login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # DockerCompose 세팅
-      - name: Set up Docker Compose
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: ./docker-compose.yml
-        env:
-          services.db-edit.environment.POSTGRES_USER: ${{ secrets.POSTGRE_USER }}
-          services.db-edit.environment.POSTGRES_PASSWORD: ${{ secrets.POSTGRE_PASSWORD }}
-          services.webapp.image: ${{ secrets.DOCKER_IMAGE }}
-          services.batch.image: ${{ secrets.DOCKER_BATCH_IMAGE }}
-
-      # Docker 이미지 빌드
-      - name: Docker Compose Build
-        run: docker-compose build
-
-      # DockerHub Push
-      - name: DockerHub Push
-        run: docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.PROJECT_NAME }}:latest
-
-#  deploy:
-#    runs-on: ubuntu-latest
-#    steps:cd
-#
-#      - name: Application Run
-#        uses: appleboy/ssh-action@v0.1.6
-#        with:
-#          host: ${{ secrets.VULTR_IP }}
-#          username: ${{ secrets.VULTR_USER_NAME }}
-#          key: ${{ secrets.VULTR_SSH_KEY }}
-#          password: ${{ secrets.VULTR_PASSWORD }}
-
-
-#      - name: Run shell script with secrets
-#        run: |
-#          export SECRET_DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
-#          export SECRET_DOCKER_PASSWORD=${{ secrets.DOCKER_PASSWORD }}
-#          export SECRET_PROJECT_NAME=${{ secrets.PROJECT_NAME }}
-#          export SECRET_VULTR_API_KEY=${{ secrets.VULTR_API_KEY }}
-#          export SECRET_VULTR_IP=${{ secrets.VULTR_IP }}
-#          export SECRET_VULTR_SSH_KEY=${{ secrets.VULTR_SSH_KEY }}
-#          export SECRET_VULTR_USER_NAME=${{ secrets.VULTR_USER_NAME }}
-#          ./scripts/deploy.sh
+      ## 터미널 접속 후 실행 -> 수정 필요
+      - name: Application Run on Remote Server
+        run: |
+          export JAR_NAME="module-api-0.0.1-SNAPSHOT.jar"
+          export PASSWORD="${{ secrets.VULTR_PW }}"
+          sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no ${{ secrets.VULTR_USER_NAME }}@${{ secrets.VULTR_IP }} \
+          "pgrep -f java | xargs kill -9 && \
+          cd \$HOME && \
+          echo pwd && \
+          mkdir -p ./logs && \
+          nohup java -jar $JAR_NAME --jasypt.encryptor.password=${{ secrets.PUBLIC_KEY }} >> ./logs/deploy_success.log 2> ./logs/deploy_error.log & "

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,15 +1,8 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle and Docker for WashPedia Project
+name: Java CI with Gradle WashPedia Project
 
 on:
   push:
-    branches: [ "feature/docker" ]
+    branches: [ "develop_CI" ]
 
 permissions:
   contents: read
@@ -37,53 +30,34 @@ jobs:
       # Gradle Build (test 제외)
       - name: Build with Gradle
         working-directory: ./module-api
-        run: ./gradlew clean build -x test
+        #run: ./gradlew build -x test
+        run: ./gradlew build
 
-      # DockerHub 로그인
-      - name: DockerHub Login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # INSTALL SSH-PASS
+      - name: Install sshpass
+        run: sudo apt-get install -y sshpass
 
-      # DockerCompose 세팅
-      - name: Set up Docker Compose
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: ./docker-compose.yml
-        env:
-          services.db-edit.environment.POSTGRES_USER: ${{ secrets.POSTGRE_USER }}
-          services.db-edit.environment.POSTGRES_PASSWORD: ${{ secrets.POSTGRE_PASSWORD }}
-          services.webapp.image: ${{ secrets.DOCKER_IMAGE }}
+      #SEND JAR
+      - name: Copy JAR file to remote server using SCP
+        run: |
+          cd module-api/build/libs/ && \
+          export PASSWORD="${{ secrets.VULTR_PW }}" && \
+          sshpass -p "$PASSWORD" scp -o StrictHostKeyChecking=no -P 22 module-api-0.0.1-SNAPSHOT.jar ${{ secrets.VULTR_USER_NAME }}@${{ secrets.VULTR_IP }}:/root
 
-      # Docker 이미지 빌드
-      - name: Docker Compose Build
-        run: docker-compose build
-
-      # DockerHub Push
-      - name: DockerHub Push
-        run: docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.PROJECT_NAME }}:latest
-
-#  deploy:
-#    runs-on: ubuntu-latest
-#    steps:cd
-#
-#      - name: Application Run
-#        uses: appleboy/ssh-action@v0.1.6
-#        with:
-#          host: ${{ secrets.VULTR_IP }}
-#          username: ${{ secrets.VULTR_USER_NAME }}
-#          key: ${{ secrets.VULTR_SSH_KEY }}
-#          password: ${{ secrets.VULTR_PASSWORD }}
-
-
-#      - name: Run shell script with secrets
-#        run: |
-#          export SECRET_DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
-#          export SECRET_DOCKER_PASSWORD=${{ secrets.DOCKER_PASSWORD }}
-#          export SECRET_PROJECT_NAME=${{ secrets.PROJECT_NAME }}
-#          export SECRET_VULTR_API_KEY=${{ secrets.VULTR_API_KEY }}
-#          export SECRET_VULTR_IP=${{ secrets.VULTR_IP }}
-#          export SECRET_VULTR_SSH_KEY=${{ secrets.VULTR_SSH_KEY }}
-#          export SECRET_VULTR_USER_NAME=${{ secrets.VULTR_USER_NAME }}
-#          ./scripts/deploy.sh
+      # CONNECT TERMINAL
+      - name: Application Run
+        run: |
+          sshpass -p ${{ secrets.VULTR_PW }} \
+          ssh -o StrictHostKeyChecking=no -A ${{ secrets.VULTR_USER_NAME }}@${{ secrets.VULTR_IP }} \
+          "JAR_NAME='module-api-0.0.1-SNAPSHOT.jar'; \
+          echo '> 현재 실행 중인 애플리케이션 pid 확인' && \
+          CURRENT_PID=\$(pgrep -f \$JAR_NAME) && \
+          if [ -z \"\$CURRENT_PID\" ]; then \
+            echo '> kill -9 \$CURRENT_PID' && \
+            sudo kill -9 \$CURRENT_PID && \
+            sleep 5 && \
+            echo '> 이전 애플리케이션이 종료되었습니다.'; \
+          fi && \
+          nohup java -jar \$JAR_NAME --jasypt.encryptor.password="${{ secrets.PUBLIC_KEY }}" >> ~/deploy.log 2> ~/deploy_err.log & \
+          echo '> 새로운 애플리케이션이 실행되었습니다.'"
+    

--- a/module-api/src/main/resources/db/migration/V1.1.2__alter_table_member_and_add_common_code.sql
+++ b/module-api/src/main/resources/db/migration/V1.1.2__alter_table_member_and_add_common_code.sql
@@ -18,8 +18,8 @@ CREATE
 OR REPLACE VIEW member_view AS
 SELECT member_no,
        id,
-       encode(pgp_sym_decrypt(password, 'changedRequired')::bytea, 'escape') as password,
-       encode(pgp_sym_decrypt(email, 'changedRequired')::bytea, 'escape')    as email,
+       encode(pgp_sym_decrypt(password, 'changeRequired')::bytea, 'escape') as password,
+       encode(pgp_sym_decrypt(email, 'changeRequired')::bytea, 'escape')    as email,
        gender,
        age,
        created_at,


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
- develop 브랜치가 merge 될 때마다 개발서버로 jar 전송 및 실행하는 배포를 수행합니다.
- 도커컴포즈 배포 및 실행 소스를 다 작성하였고 개발서버 터미널에서 관련 수행이 정상 동작함을 확인하였으나 도커에선 vm옵션을 줄 수 없어 -Djasypt 가 주입되지 않아 정상적인 기능 이용이 불가합니다. (배포 소스는 따로 백업해두었고, IDE에서 jasypt 미설정시 발생하는 에러와 동일함을 확인.)
- 생성 된 jar 파일 전송까지 확인이 되었으나 nohup 실행이 되지 않는 이슈가 있습니다.
- devlop branch에서 수행하려면 해당 파일의 on.push.branches 항목을 바꿔야 합니다.

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - _여기에 세부 변경사항을 설명해주세요_
  - docker를 쓰지 않는 수동배포이므로 코드 구조가 완전히 바뀌었습니다.
  - 기존의 미완성 된 배포코드가 docker 배포, docker-compose배포가 혼재되어있어 정체성이 확실하지 않았습니다.
  - 기존 코드를 최대한 살렸을 때 gradle build -> docker build -> dockerhub push -> dev server login -> dockerhub pull -> docker run 방식이 되고, 이는 일반적인 도커 이미지 생성 및 수동배포와 같습니다.
  - 도커컴포즈 배포 방식은 docker-compose 명령어를 통해 docker-compose build를 한 뒤 docker-compose up / down 명령어를 통해 여러 서비스를 한번에 올리고 내리는 방법입니다.
docker-compose.yml은 dockerhub에 업로드를 할 수 없으므로 결국 git repository pull -> gradle build -> docker-compose build -> up 순으로 수행됩니다. (참고 예시 : redash의 docker-compose 배포가 이러한 구조를 하고 있습니다.)
  - 컴포즈 배포 테스트를 완료하였으나 jasypt 이슈로 인해 철회하고, 원초적인 수동배포로 전환하였습니다.
<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
- 브랜드 로고 및 제품 이미지 사용 허가 협조 이메일 발신
- 도메인 구매
- 카카오맵API / 유튜브API 확인 / 이미지관련 인프라 검수

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
