### PR TITLE
Feature :: 위해우려제품 상세 정보를 초록누리 API 로 불러와서 저장하기

### DIFF
--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductDetailClient.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductDetailClient.java
@@ -1,6 +1,7 @@
 package com.kernel360.modulebatch.concernedproduct.client;
 
-import com.kernel360.brand.entity.Brand;
+import com.kernel360.ecolife.entity.ConcernedProduct;
+import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,7 +13,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
-public class ConcernedProductListClient {
+public class ConcernedProductDetailClient {
 
     @Value("${external.ecolife-api.path}")
     private String BASE_PATH;
@@ -22,19 +23,25 @@ public class ConcernedProductListClient {
 
     private final RestClient restClient;
 
-    public ConcernedProductListClient() {
+    public ConcernedProductDetailClient() {
         this.restClient = RestClient.builder()
                                     .build();
+        log.info("ConcernedProductDetailClient initialized with BASE_PATH: " + BASE_PATH);
+    }
+    @PostConstruct
+    public void postConstruct() {
+        log.info("ConcernedProductDetailClient postConstruct with BASE_PATH: " + BASE_PATH);
     }
 
-    public String getXmlResponse(Brand brand, Long pageNumber) {
-        return restClient.post().uri(buildUri(brand, pageNumber))
+    public String getXmlResponse(ConcernedProduct concernedProduct) {
+
+        return restClient.get().uri(buildUri(concernedProduct))
                          .accept(MediaType.APPLICATION_XML)
                          .acceptCharset(StandardCharsets.UTF_8)
                          .retrieve()
                          .onStatus(HttpStatusCode::is4xxClientError,
                                  ((request, response) -> {
-                                     log.debug("[ERROR] :: 4XX 에러 발생"
+                                     log.error("[ERROR] :: 4XX 에러 발생"
                                              + response.getStatusText());
                                      throw new RuntimeException(
                                              response.getStatusCode()
@@ -43,7 +50,7 @@ public class ConcernedProductListClient {
                                  }))
                          .onStatus(HttpStatusCode::is5xxServerError,
                                  (request, response) -> {
-                                     log.debug("[ERROR] :: 5XX 에러 발생"
+                                     log.error("[ERROR] :: 5XX 에러 발생"
                                              + response.getStatusText());
                                      throw new RuntimeException(
                                              response.getStatusCode()
@@ -51,21 +58,17 @@ public class ConcernedProductListClient {
                                                                .toString());
                                  })
                          .onStatus(HttpStatusCode::is2xxSuccessful,
-                                 ((request, response) -> log.info("[INFO] :: api 요청 성공"
+                                 ((request, response) -> log.debug("[INFO] :: 2XX API 요청 성공"
                                          + response.getBody())))
                          .body(String.class);
     }
 
-    public String buildUri(Brand brand, Long pageNumber) {
+    public String buildUri(ConcernedProduct concernedProduct) {
 
         return UriComponentsBuilder.fromHttpUrl(BASE_PATH)
                                    .queryParam("AuthKey", AUTH_KEY)
-                                   .queryParam("ServiceName", "slfsfcfst01List")
-                                   .queryParam("PageCount", "20")
-                                   .queryParam("PageNum", String.valueOf(pageNumber))
-                                   .queryParam("compNm", brand.getCompanyName())
-                                   .build()
+                                   .queryParam("ServiceName", "slfsfcfst01Detail")
+                                   .queryParam("prdtNo", concernedProduct.getProductNo())
                                    .toUriString();
     }
 }
-

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductDetailClient.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/client/ConcernedProductDetailClient.java
@@ -58,7 +58,7 @@ public class ConcernedProductDetailClient {
                                                                .toString());
                                  })
                          .onStatus(HttpStatusCode::is2xxSuccessful,
-                                 ((request, response) -> log.debug("[INFO] :: 2XX API 요청 성공"
+                                 ((request, response) -> log.info("[INFO] :: 2XX API 요청 성공"
                                          + response.getBody())))
                          .body(String.class);
     }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
@@ -1,10 +1,11 @@
 package com.kernel360.modulebatch.concernedproduct.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.kernel360.ecolife.entity.ConcernedProduct;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JacksonXmlRootElement(localName = "row")
@@ -16,8 +17,7 @@ public record ConcernedProductDetailDto(
         @JacksonXmlProperty(localName = "inspct_org")
         String inspectedOrganization,
         @JacksonXmlProperty(localName = "issu_date")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-        LocalDate issuedDate,
+        String issuedDate,
         @JacksonXmlProperty(localName = "upper_item")
         String upperItem,
         @JacksonXmlProperty(localName = "prdt_type")
@@ -44,7 +44,7 @@ public record ConcernedProductDetailDto(
             String productName,
             String productMasterId,
             String inspectedOrganization,
-            LocalDate issuedDate,
+            String issuedDate,
             String upperItem,
             String productType,
             String renewedType,
@@ -61,4 +61,13 @@ public record ConcernedProductDetailDto(
                 manufactureNation, productDefinition, item, manufacture, companyName);
     }
 
+    public static ConcernedProduct toEntity(ConcernedProductDetailDto detailDto, ConcernedProductDto productDto) {
+        return ConcernedProduct.of(productDto.productNo(), productDto.productName(), productDto.reportNumber(),
+                productDto.item(), productDto.companyName(), detailDto.inspectedOrganization,
+                LocalDate.parse(detailDto.issuedDate, DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                detailDto.upperItem, detailDto.productType,
+                detailDto.renewedType(), detailDto.safetyInspectionStandard(), detailDto.kidProtectPackage,
+                detailDto.manufactureNation(),
+                detailDto.productDefinition(), detailDto.manufacture());
+    }
 }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDetailDto.java
@@ -40,26 +40,6 @@ public record ConcernedProductDetailDto(
         String manufacture,
         @JacksonXmlProperty(localName = "comp_nm")
         String companyName) {
-    public static ConcernedProductDetailDto of(
-            String productName,
-            String productMasterId,
-            String inspectedOrganization,
-            String issuedDate,
-            String upperItem,
-            String productType,
-            String renewedType,
-            String reportNumber,
-            String safetyInspectionStandard,
-            String kidProtectPackage,
-            String manufactureNation,
-            String productDefinition,
-            String item,
-            String manufacture,
-            String companyName) {
-        return new ConcernedProductDetailDto(productName, productMasterId, inspectedOrganization, issuedDate,
-                upperItem, productType, renewedType, reportNumber, safetyInspectionStandard, kidProtectPackage,
-                manufactureNation, productDefinition, item, manufacture, companyName);
-    }
 
     public static ConcernedProduct toEntity(ConcernedProductDetailDto detailDto, ConcernedProductDto productDto) {
         return ConcernedProduct.of(productDto.productNo(), productDto.productName(), productDto.reportNumber(),

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/dto/ConcernedProductDto.java
@@ -18,4 +18,10 @@ public record ConcernedProductDto(
         return ConcernedProduct.of(dto.productNo, dto.productName(),
                 dto.reportNumber(), dto.item(), dto.companyName());
     }
+
+    public static ConcernedProductDto of(String productNo, String productName, String reportNumber, String item,
+                                         String companyName) {
+
+        return new ConcernedProductDto(productNo, productName, reportNumber, item, companyName);
+    }
 }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/core/FetchConcernedProductDetailJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/core/FetchConcernedProductDetailJobConfig.java
@@ -1,0 +1,114 @@
+package com.kernel360.modulebatch.concernedproduct.job.core;
+
+import com.kernel360.ecolife.entity.ConcernedProduct;
+import com.kernel360.modulebatch.concernedproduct.job.infra.ConcernedProductDetailItemProcessor;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FetchConcernedProductDetailJobConfig {
+
+    private final ConcernedProductDetailItemProcessor concernedProductDetailItemProcessor;
+
+    private final EntityManagerFactory emf;
+
+    @Bean
+    public Job fetchConcernedProductDetailJob(JobRepository jobRepository,
+                                              @Qualifier("fetchConcernedProductDetailStep") Step fetchConcernedProductDetailStep) {
+        log.info("FetchConcernedProductDetailJobConfig initialized");
+
+        return new JobBuilder("fetchConcernedProductDetailJobConfig", jobRepository)
+                .start(fetchConcernedProductDetailStep)
+                .incrementer(new RunIdIncrementer())
+                .listener(new FetchConcernedProductDetailJobListener())
+                .build();
+    }
+
+    @Bean
+    public Step fetchConcernedProductDetailStep(JobRepository jobRepository,
+                                                PlatformTransactionManager transactionManager) {
+
+        return new StepBuilder("fetchConcernedProductDetailStep", jobRepository)
+                .<ConcernedProduct, ConcernedProduct>chunk(100, transactionManager)
+                .listener(new FetchConcernedProductDetailStepListener())
+                .reader(concernedProductDetailItemReader())
+                .processor(concernedProductDetailItemProcessor)
+                .writer(concernedProductItemWriter(emf))
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<ConcernedProduct> concernedProductDetailItemReader() {
+        String jpql = "SELECT cp FROM ConcernedProduct cp";
+
+        return new JpaPagingItemReaderBuilder<ConcernedProduct>()
+                .queryString(jpql)
+                .entityManagerFactory(emf)
+                .name("concernedProductDetailJpaItemReader")
+                // FIXME :: 트랜잭션 관리 개선, 작업의 병렬성 조정, 사용자 정의 Reader 를 만드는 식으로 페이지 크기에 따른 읽기 문제를 해결해야 함.
+                .pageSize(1000)
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaItemWriter<ConcernedProduct> concernedProductItemWriter(EntityManagerFactory emf) {
+        JpaItemWriter<ConcernedProduct> jpaItemWriter = new JpaItemWriter<>();
+        jpaItemWriter.setEntityManagerFactory(emf);
+
+        return jpaItemWriter;
+    }
+
+    //-- Execution Listener --//
+
+    public static class FetchConcernedProductDetailJobListener implements JobExecutionListener {
+        @Override
+        public void beforeJob(JobExecution jobExecution) {
+            log.info("{} starts", jobExecution.getJobInstance().getJobName());
+        }
+
+        @Override
+        public void afterJob(JobExecution jobExecution) {
+            log.info("{} ends", jobExecution.getJobInstance().getJobName());
+        }
+    }
+
+    public static class FetchConcernedProductDetailStepListener implements StepExecutionListener{
+        @Override
+        public void beforeStep(StepExecution stepExecution) {
+            log.info("{} starts", stepExecution.getStepName());
+        }
+
+        @Override
+        public ExitStatus afterStep(StepExecution stepExecution) {
+            log.info("StepExecutionListener - afterStep, step name: {}, status: {}", stepExecution.getStepName(), stepExecution.getStatus());
+            log.info("StepExecutionListener - ReadCount: {}, WriteCount: {}, FilterCount: {}, ReadSkipCount: {}, ProcessSkipCount: {}, WriteSkipCount: {}",
+                    stepExecution.getReadCount(), stepExecution.getWriteCount(), stepExecution.getFilterCount(),
+                    stepExecution.getReadSkipCount(), stepExecution.getProcessSkipCount(), stepExecution.getWriteSkipCount());
+            return StepExecutionListener.super.afterStep(stepExecution);
+        }
+    }
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductDetailItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductDetailItemProcessor.java
@@ -1,0 +1,69 @@
+package com.kernel360.modulebatch.concernedproduct.job.infra;
+
+import com.kernel360.ecolife.entity.ConcernedProduct;
+import com.kernel360.modulebatch.concernedproduct.client.ConcernedProductDetailClient;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductDetailDto;
+import com.kernel360.modulebatch.concernedproduct.dto.ConcernedProductDto;
+import com.kernel360.modulebatch.concernedproduct.service.ConcernedProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcernedProductDetailItemProcessor implements ItemProcessor<ConcernedProduct, ConcernedProduct> {
+
+    private final ConcernedProductService service;
+
+    private final ConcernedProductDetailClient client;
+
+    /**
+     * @param item ItemReader 에서 넘겨받은 엔티티
+     * @return 업데이트할 엔티티 정보로 변경해서 반환
+     */
+    @Override
+    public ConcernedProduct process(@NonNull ConcernedProduct item) throws Exception {
+        log.debug("Processing {}", item.getProductName());
+
+        if (item.getInspectedOrganization() != null) {
+            return null;
+        }
+
+        String response = fetchXmlResponse(item);
+        ConcernedProductDetailDto detailDto = service.deserializeXml2DetailDto(response)
+                                                     .concernedProductDetailDtoList()
+                                                     .get(0);
+
+        ConcernedProductDto productDto = ConcernedProductDto.of(
+                item.getProductNo(),
+                item.getProductName(),
+                item.getReportNumber(),
+                item.getItem(),
+                item.getCompanyName()
+        );
+
+        return ConcernedProductDetailDto.toEntity(detailDto, productDto);
+    }
+
+    private String fetchXmlResponse(ConcernedProduct concernedProduct) {
+        log.info("Fetch item Id = {}", concernedProduct);
+        String xmlResponse = client.getXmlResponse(concernedProduct);
+        log.info("Response accepted : {}", xmlResponse);
+
+        return removeInvalidXmlCharacters(xmlResponse);
+    }
+
+    /**
+     * 유효하지 않은 문자열 패턴을 필터링하는 메서드
+     */
+    public String removeInvalidXmlCharacters(String xmlString) {
+        // XML 1.0 Specification 을 준수하는 ASCII printable characters (REPLACEMENT_CHARACTER)
+        String pattern = "[^\t\r\n -\uD7FF\uE000-\uFFFD\ud800\udc00-\udbff\udfff]";
+
+        return xmlString.replaceAll(pattern, "");
+    }
+}
+

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemProcessor.java
@@ -11,8 +11,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class ConcernedProductListItemProcessor implements ItemProcessor<Brand, List<ConcernedProductDto>> {
     private final ConcernedProductListClient client;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemWriter.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/concernedproduct/job/infra/ConcernedProductListItemWriter.java
@@ -6,7 +6,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
 
+@Component
 @RequiredArgsConstructor
 public class ConcernedProductListItemWriter implements ItemWriter<List<ConcernedProductDto>> {
 

--- a/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
@@ -14,23 +14,37 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@Profile({"local", "prod"})
+@Profile({"local", "dev"})
 public class ConcernedProductScheduler {
     private final Job fetchConcernedProductListFromBrandJob;
+    private final Job fetchConcernedProductDetailJob;
     private final JobLauncher jobLauncher;
 
     @Autowired
     public ConcernedProductScheduler(
             @Qualifier("fetchConcernedProductListFromBrandJob") Job fetchConcernedProductListJob,
+            @Qualifier("fetchConcernedProductDetailJob") Job fetchConcernedProductDetailJob,
             JobLauncher jobLauncher) {
 
         this.fetchConcernedProductListFromBrandJob = fetchConcernedProductListJob;
+        this.fetchConcernedProductDetailJob = fetchConcernedProductDetailJob;
         this.jobLauncher = jobLauncher;
     }
 
-    @Scheduled(cron = "0 30 11,13 * * TUE", zone = "Asia/Seoul")
+    /**
+     * 매주 목요일 19시 00분 실행
+     */
+    @Scheduled(cron = "0 0 19 * * THU", zone = "Asia/Seoul")
     public void executeFetchConcernedProductListJob() {
         executeJob(fetchConcernedProductListFromBrandJob);
+    }
+
+    /**
+     * 매주 목요일 19시 30분 실행
+     */
+    @Scheduled(cron = "0 30 19 * * THU", zone = "Asia/Seoul")
+    public void executeFetchConcernedProductDetailJob() {
+        executeJob(fetchConcernedProductDetailJob);
     }
 
     private synchronized void executeJob(Job job) {

--- a/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProduct.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/entity/ConcernedProduct.java
@@ -4,17 +4,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @Table(name = "concerned_product")
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ConcernedProduct {
+public class ConcernedProduct extends ConcernedProductDetail {
     @Id
     @Column(name = "prdt_no", nullable = false)
     private String productNo;
@@ -31,8 +30,48 @@ public class ConcernedProduct {
     @Column(name = "comp_nm")
     private String companyName;
 
+    private ConcernedProduct(String productNo, String productName, String reportNumber, String item,
+                             String companyName) {
+
+        this.productNo = productNo;
+        this.productName = productName;
+        this.reportNumber = reportNumber;
+        this.item = item;
+        this.companyName = companyName;
+    }
+
+    public ConcernedProduct(String productNo, String productName, String reportNumber, String item, String companyName,
+                            String inspectedOrganization, LocalDate issuedDate, String upperItem, String productType,
+                            String renewedType,
+                            String safetyInspectionStandard, String kidProtectPackage, String manufactureNation,
+                            String productDefinition, String manufacture) {
+
+        super(inspectedOrganization, issuedDate, upperItem, productType, renewedType, safetyInspectionStandard,
+                kidProtectPackage, manufactureNation, productDefinition, manufacture);
+        this.productNo = productNo;
+        this.productName = productName;
+        this.reportNumber = reportNumber;
+        this.item = item;
+        this.companyName = companyName;
+    }
+
+
     public static ConcernedProduct of(String productNo, String productName, String reportNumber, String item,
                                       String companyName) {
+
         return new ConcernedProduct(productNo, productName, reportNumber, item, companyName);
     }
+
+    public static ConcernedProduct of(String productNo, String productName, String reportNumber, String item,
+                                      String companyName, String inspectedOrganization, LocalDate issuedDate,
+                                      String upperItem, String productType, String renewedType,
+                                      String safetyInspectionStandard, String kidProtectPackage,
+                                      String manufactureNation, String productDefinition, String manufacture) {
+
+        return new ConcernedProduct(productNo, productName, reportNumber, item, companyName, inspectedOrganization,
+                issuedDate, upperItem, productType, renewedType, safetyInspectionStandard, kidProtectPackage,
+                manufactureNation, productDefinition, manufacture);
+
+    }
+
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`위해우려제품 상세 정보를 저장할 수 있습니다.`

<br>

## 🔨 Modified
> 위해우려제품 상세 정보를 초록누리 API 로 불러와서 저장합니다
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/88d2b648-c7c9-481f-b38a-6305c02a558c)
 - FetchConcernedProductDetailJobConfig.java 를 중심으로 배치 작업을 구성하였습니다.

<br>

## 🌟 More
- _Product 테이블로 위해우려제품 정보를 옮기는 배치 작업 구현_
- _PagingReader 가 첫 페이지를 읽고 다음 페이지를 읽지 않는 문제 해결하기_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #90
