### PR TITLE
Feature :: 위해우려제품 테이블에서 제품정보를 Product 테이블로 옮기는 기능

### DIFF
--- a/module-api/src/main/resources/db/migration/V1.1.3__create_concerned_product_table.sql
+++ b/module-api/src/main/resources/db/migration/V1.1.3__create_concerned_product_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE if not exists ConcernedProduct
+CREATE TABLE if not exists concerned_product
 (
     prdt_no                    VARCHAR(255) PRIMARY KEY,
     prdt_name                  VARCHAR(255) NOT NULL,

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/ImportProductFromConcernedProductJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/ImportProductFromConcernedProductJobConfig.java
@@ -1,0 +1,117 @@
+package com.kernel360.modulebatch.product.job;
+
+import com.kernel360.brand.entity.Brand;
+import com.kernel360.modulebatch.product.job.infra.ConcernedProductToProductListItemProcessor;
+import com.kernel360.product.entity.Product;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+//@ComponentScan("com.kernel360.product")
+public class ImportProductFromConcernedProductJobConfig {
+
+    private final ConcernedProductToProductListItemProcessor concernedProductToProductListItemProcessor;
+
+    private final EntityManagerFactory emf;
+
+    @Bean
+    public Job importProductFromConcernedProductJob(JobRepository jobRepository,
+                                                    @Qualifier("importProductFromConcernedProductStep") Step importProductFromConcernedProductStep) {
+
+        return new JobBuilder("importProductFromConcernedProductJob", jobRepository)
+                .start(importProductFromConcernedProductStep)
+                .listener(new importProductFromConcernedProductJobListener())
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step importProductFromConcernedProductStep(JobRepository jobRepository,
+                                                      PlatformTransactionManager transactionManager) {
+
+        return new StepBuilder("importProductFromConcernedProductStep", jobRepository)
+                .<Brand, List<Product>>chunk(10, transactionManager)
+                .listener(new importProductFromConcernedProductStepListener())
+                .reader(importProductFromConcernedProductJpaPagingItemReader())
+                .processor(concernedProductToProductListItemProcessor)
+                .writer(productListWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<Brand> importProductFromConcernedProductJpaPagingItemReader() {
+        String jpql = "SELECT b FROM Brand b";
+
+        return new JpaPagingItemReaderBuilder<Brand>()
+                .pageSize(100)
+                .queryString(jpql)
+                .entityManagerFactory(emf)
+                .name("importProductFromConcernedProductJpaPagingItemReader")
+                .build();
+    }
+
+    private JpaProductListWriter<Product> productListWriter() {
+        JpaItemWriter<Product> writer = new JpaItemWriter<>();
+        writer.setEntityManagerFactory(emf);
+
+        return new JpaProductListWriter<>(writer);
+    }
+
+    //-- Execution Listener --//
+
+    public static class importProductFromConcernedProductJobListener implements JobExecutionListener {
+        @Override
+        public void beforeJob(JobExecution jobExecution) {
+            log.info("{} starts", jobExecution.getJobInstance().getJobName());
+        }
+
+        @Override
+        public void afterJob(JobExecution jobExecution) {
+            log.info("{} ends", jobExecution.getJobInstance().getJobName());
+        }
+    }
+
+
+    public static class importProductFromConcernedProductStepListener implements StepExecutionListener {
+        @Override
+        public void beforeStep(StepExecution stepExecution) {
+            log.info("{} starts", stepExecution.getStepName());
+        }
+
+        @Override
+        public ExitStatus afterStep(StepExecution stepExecution) {
+            log.info("StepExecutionListener - afterStep, step name: {}, status: {}", stepExecution.getStepName(),
+                    stepExecution.getStatus());
+            log.info(
+                    "StepExecutionListener - ReadCount: {}, WriteCount: {}, FilterCount: {}, ReadSkipCount: {}, ProcessSkipCount: {}, WriteSkipCount: {}",
+                    stepExecution.getReadCount(), stepExecution.getWriteCount(), stepExecution.getFilterCount(),
+                    stepExecution.getReadSkipCount(), stepExecution.getProcessSkipCount(),
+                    stepExecution.getWriteSkipCount());
+            return StepExecutionListener.super.afterStep(stepExecution);
+        }
+    }
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
@@ -1,7 +1,7 @@
 package com.kernel360.modulebatch.product.job.core;
 
 import com.kernel360.brand.entity.Brand;
-import com.kernel360.modulebatch.product.job.infra.JpaProductListWriter;
+import com.kernel360.modulebatch.product.job.JpaProductListWriter;
 import com.kernel360.modulebatch.product.job.infra.ConcernedProductToProductListItemProcessor;
 import com.kernel360.product.entity.Product;
 import jakarta.persistence.EntityManagerFactory;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
@@ -1,6 +1,7 @@
-package com.kernel360.modulebatch.product.job;
+package com.kernel360.modulebatch.product.job.core;
 
 import com.kernel360.brand.entity.Brand;
+import com.kernel360.modulebatch.product.job.infra.JpaProductListWriter;
 import com.kernel360.modulebatch.product.job.infra.ConcernedProductToProductListItemProcessor;
 import com.kernel360.product.entity.Product;
 import jakarta.persistence.EntityManagerFactory;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ConcernedProductToProductListItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ConcernedProductToProductListItemProcessor.java
@@ -1,0 +1,150 @@
+package com.kernel360.modulebatch.product.job.infra;
+
+import com.kernel360.brand.entity.Brand;
+import com.kernel360.ecolife.entity.ConcernedProduct;
+import com.kernel360.ecolife.repository.ConcernedProductRepository;
+import com.kernel360.modulebatch.product.dto.ProductDto;
+import com.kernel360.product.entity.Product;
+import com.kernel360.product.entity.SafetyStatus;
+import com.kernel360.product.repository.ProductRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ConcernedProductToProductListItemProcessor implements ItemProcessor<Brand, List<Product>> {
+
+    private final ConcernedProductRepository concernedProductRepository;
+
+    private final ProductRepository productRepository;
+
+    @Override
+    public List<Product> process(Brand brand) throws Exception {
+        List<ConcernedProduct> concernedProductList = concernedProductRepository
+                .findByBrandNameAndCompanyName(
+                        "%" + brand.getBrandName().replaceAll(" ", "%") + "%",
+                        "%" + brand.getCompanyName().replaceAll(" ", "%") + "%");
+
+        List<ProductDto> productDtoList = concernedProductList.stream()
+                                                              .filter(cp -> cp.getInspectedOrganization() != null)
+                                                              .map(cp -> ProductDto.of(cp.getProductName(),
+                                                                      null,
+                                                                      null,
+                                                                      "취하".equals(cp.getProductType())
+                                                                              ? SafetyStatus.DANGER
+                                                                              : SafetyStatus.CONCERN,
+                                                                      0,
+                                                                      cp.getCompanyName(),
+                                                                      cp.getReportNumber(),
+                                                                      cp.getProductType(),
+                                                                      LocalDate.from(cp.getIssuedDate()),
+                                                                      cp.getSafetyInspectionStandard(),
+                                                                      cp.getUpperItem(),
+                                                                      cp.getItem(),
+                                                                      null,
+                                                                      null,
+                                                                      null,
+                                                                      null, null, null, null,
+                                                                      null, null, null, null,
+                                                                      cp.getManufacture(), null,
+                                                                      cp.getManufactureNation(),
+                                                                      brand))
+                                                              .toList();
+
+        return convertToProductList(productDtoList);
+    }
+
+    private List<Product> convertToProductList(List<ProductDto> productDtoList) {
+        List<Product> productList = new ArrayList<>();
+
+        for (ProductDto productDto : productDtoList) {
+            Optional<Product> foundProduct = productRepository.findProductByProductNameAndCompanyName(
+                    productDto.productName(), "%" + getCompanyNameWithoutSlash(productDto.companyName()) + "%");
+
+            boolean foundInList = productList.stream().anyMatch(
+                    product -> product.getProductName().equals(productDto.productName()) &&
+                            product.getCompanyName().equals(productDto.companyName()));
+
+            if (foundInList) { // 현재 처리할 데이터에 이미 추가가 되어 있다면 무시
+                continue;
+            }
+
+            if (foundProduct.isEmpty()) {
+                Product newProduct = generateNewProduct(productDto);
+                productList.add(newProduct);
+                continue;
+            }
+
+            if (productDto.issuedDate().isAfter(foundProduct.get().getIssuedDate())) { // 저장된 데이터보다 최신의 제품 데이터라면
+                foundProduct.get().updateDetail(productDto.barcode(),
+                        productDto.imageSource(),
+                        productDto.reportNumber(),
+                        String.valueOf(productDto.safetyStatus()),
+                        productDto.issuedDate(),
+                        productDto.safetyInspectionStandard(),
+                        productDto.upperItem(),
+                        productDto.item(),
+                        productDto.propose(),
+                        productDto.weight(),
+                        productDto.usage(),
+                        productDto.usagePrecaution(),
+                        productDto.firstAid(),
+                        productDto.mainSubstance(),
+                        productDto.allergicSubstance(),
+                        productDto.otherSubstance(),
+                        productDto.preservative(),
+                        productDto.surfactant(),
+                        productDto.fluorescentWhitening(),
+                        productDto.manufactureType(),
+                        productDto.manufactureMethod(),
+                        getNation(productDto),
+                        productDto.brand());
+            }
+        }
+
+        return productList;
+    }
+
+    private static Product generateNewProduct(ProductDto productDto) {
+
+        return Product.of(productDto.productName(), productDto.barcode(),
+                productDto.imageSource(), productDto.reportNumber(), String.valueOf(productDto.safetyStatus()),
+                productDto.viewCount(), getCompanyNameWithoutSlash(productDto.companyName()), productDto.productType(),
+                productDto.issuedDate(), productDto.safetyInspectionStandard(), productDto.upperItem(),
+                productDto.item(), productDto.propose(), productDto.weight(), productDto.usage(),
+                productDto.usagePrecaution(), productDto.firstAid(), productDto.mainSubstance(),
+                productDto.allergicSubstance(), productDto.otherSubstance(), productDto.preservative(),
+                productDto.surfactant(), productDto.fluorescentWhitening(), productDto.manufactureType(),
+                productDto.manufactureMethod(), getNation(productDto), productDto.brand());
+    }
+
+    public static String getCompanyNameWithoutSlash(String companyName) {
+        int index = companyName.indexOf("/");
+        if (index != -1) {
+            return companyName.substring(0, index);
+        }
+        return companyName;
+
+    }
+
+    private static String getNation(ProductDto productDto) {
+        String nation;
+        if (productDto.manufactureType().equals("수입")) {
+            nation = productDto.brand().getNationName();
+        } else {
+            nation = "대한민국";
+        }
+        return nation;
+    }
+
+
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
@@ -18,16 +18,19 @@ import org.springframework.stereotype.Component;
 public class ConcernedProductScheduler {
     private final Job fetchConcernedProductListFromBrandJob;
     private final Job fetchConcernedProductDetailJob;
+    private final Job importProductFromConcernedProductJob;
     private final JobLauncher jobLauncher;
 
     @Autowired
     public ConcernedProductScheduler(
             @Qualifier("fetchConcernedProductListFromBrandJob") Job fetchConcernedProductListJob,
             @Qualifier("fetchConcernedProductDetailJob") Job fetchConcernedProductDetailJob,
+            @Qualifier("importProductFromConcernedProductJob") Job importProductFromConcernedProductJob,
             JobLauncher jobLauncher) {
 
         this.fetchConcernedProductListFromBrandJob = fetchConcernedProductListJob;
         this.fetchConcernedProductDetailJob = fetchConcernedProductDetailJob;
+        this.importProductFromConcernedProductJob = importProductFromConcernedProductJob;
         this.jobLauncher = jobLauncher;
     }
 
@@ -45,6 +48,14 @@ public class ConcernedProductScheduler {
     @Scheduled(cron = "0 30 19 * * THU", zone = "Asia/Seoul")
     public void executeFetchConcernedProductDetailJob() {
         executeJob(fetchConcernedProductDetailJob);
+    }
+
+    /**
+     * 매주 목요일 20시 00분 실행
+     */
+    @Scheduled(cron = "0 0 20 * * THU", zone = "Asia/Seoul")
+    public void executeImportProductFromConcernedProductJob() {
+        executeJob(importProductFromConcernedProductJob);
     }
 
     private synchronized void executeJob(Job job) {

--- a/module-domain/src/main/java/com/kernel360/ecolife/repository/ConcernedProductRepository.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/repository/ConcernedProductRepository.java
@@ -1,7 +1,19 @@
 package com.kernel360.ecolife.repository;
 
 import com.kernel360.ecolife.entity.ConcernedProduct;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-public interface ConcernedProductRepository extends JpaRepository<ConcernedProduct,String> {
+@Repository
+public interface ConcernedProductRepository extends JpaRepository<ConcernedProduct, String> {
+    @Query(value = "SELECT cp.* FROM concerned_product cp "
+            + "JOIN LATERAL (SELECT cp2.prdt_name, MAX(cp2.issued_date) AS max_issu_date "
+            + "FROM concerned_product cp2 WHERE cp2.comp_nm LIKE :companyName AND cp2.prdt_name LIKE :brandName GROUP BY cp2.prdt_name) max_dates "
+            + "ON cp.prdt_name = max_dates.prdt_name AND cp.issued_date = max_dates.max_issu_date "
+            + "ORDER BY max_dates.max_issu_date DESC", nativeQuery = true)
+    List<ConcernedProduct> findByBrandNameAndCompanyName(@Param("brandName") String brandName,
+                                                         @Param("companyName") String companyName);
 }

--- a/module-domain/src/main/java/com/kernel360/product/repository/ProductRepository.java
+++ b/module-domain/src/main/java/com/kernel360/product/repository/ProductRepository.java
@@ -26,6 +26,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query(value = "SELECT p FROM Product p WHERE p.productName = :productName "
             + "AND p.companyName like :companyName")
-    Optional<Product> findProductByProductNameAndReportNumber(@Param("productName") String productName,
-                                                              @Param("companyName") String companyName);
+    Optional<Product> findProductByProductNameAndCompanyName(@Param("productName") String productName,
+                                                             @Param("companyName") String companyName);
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`위해우려제품 테이블에서 제품정보를 Product 테이블로 옮기는 배치 작업`

<br>

## 🔨 Modified
> 위해우려제품 테이블에서 제품정보를 Product 테이블로 옮길 수 있습니다.
  - 아래 스케쥴러를 실행시켜서 제품 정보를 로드하게 됩니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/f6aba858-022e-41c4-a1db-26884c9eac7c)


<br>

## 🌟 More
-  _위해우려제품 API 가 19년 이전에 적용되던 규정이라 신고대상생활화학 제품 API 에서 제공되는 정보에 비해 부족한 점이 많습니다. 예를 들어, 제품사용목적이나 주요 물질등의 세부 정보를 제공하지 않습니다._
   - 19년 이후로 갱신/변경된 제품이라면 신고대상생활화학 제품 API 에 제품이력이 있지만, 그렇지 않은 경우 제품 정보를 신고대상생활화학 제품 API만으로 찾을 수 없기에 위해우려제품 API 를 별도 조회하였습니다. 
   - 위해우려제품 API 응답은 제품구분(대표/파생) 을 구분짓지 않고 모두 '합격'으로 표기하고 있어 다소 문제가 있습니다.
   - 위해우려제품 API가 굳이 필요하지 않다고 판단되면 concerned_product 관련 코드를 롤백해야 합니다.
- _전성분 공개 제품 목록을 조회하여 제품 정보를 업데이트하기_
- _위반제품 목록을 조회하여 제품 정보 업데이트하기_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #97
