### PR TITLE
Refactor :: 배치 모듈 내부 클래스 디렉터리 정리

### DIFF
--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/ImportProductFromConcernedProductJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/ImportProductFromConcernedProductJobConfig.java
@@ -1,0 +1,117 @@
+package com.kernel360.modulebatch.product.job;
+
+import com.kernel360.brand.entity.Brand;
+import com.kernel360.modulebatch.product.job.infra.ConcernedProductToProductListItemProcessor;
+import com.kernel360.product.entity.Product;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+//@ComponentScan("com.kernel360.product")
+public class ImportProductFromConcernedProductJobConfig {
+
+    private final ConcernedProductToProductListItemProcessor concernedProductToProductListItemProcessor;
+
+    private final EntityManagerFactory emf;
+
+    @Bean
+    public Job importProductFromConcernedProductJob(JobRepository jobRepository,
+                                                    @Qualifier("importProductFromConcernedProductStep") Step importProductFromConcernedProductStep) {
+
+        return new JobBuilder("importProductFromConcernedProductJob", jobRepository)
+                .start(importProductFromConcernedProductStep)
+                .listener(new importProductFromConcernedProductJobListener())
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step importProductFromConcernedProductStep(JobRepository jobRepository,
+                                                      PlatformTransactionManager transactionManager) {
+
+        return new StepBuilder("importProductFromConcernedProductStep", jobRepository)
+                .<Brand, List<Product>>chunk(10, transactionManager)
+                .listener(new importProductFromConcernedProductStepListener())
+                .reader(importProductFromConcernedProductJpaPagingItemReader())
+                .processor(concernedProductToProductListItemProcessor)
+                .writer(productListWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<Brand> importProductFromConcernedProductJpaPagingItemReader() {
+        String jpql = "SELECT b FROM Brand b";
+
+        return new JpaPagingItemReaderBuilder<Brand>()
+                .pageSize(100)
+                .queryString(jpql)
+                .entityManagerFactory(emf)
+                .name("importProductFromConcernedProductJpaPagingItemReader")
+                .build();
+    }
+
+    private JpaProductListWriter<Product> productListWriter() {
+        JpaItemWriter<Product> writer = new JpaItemWriter<>();
+        writer.setEntityManagerFactory(emf);
+
+        return new JpaProductListWriter<>(writer);
+    }
+
+    //-- Execution Listener --//
+
+    public static class importProductFromConcernedProductJobListener implements JobExecutionListener {
+        @Override
+        public void beforeJob(JobExecution jobExecution) {
+            log.info("{} starts", jobExecution.getJobInstance().getJobName());
+        }
+
+        @Override
+        public void afterJob(JobExecution jobExecution) {
+            log.info("{} ends", jobExecution.getJobInstance().getJobName());
+        }
+    }
+
+
+    public static class importProductFromConcernedProductStepListener implements StepExecutionListener {
+        @Override
+        public void beforeStep(StepExecution stepExecution) {
+            log.info("{} starts", stepExecution.getStepName());
+        }
+
+        @Override
+        public ExitStatus afterStep(StepExecution stepExecution) {
+            log.info("StepExecutionListener - afterStep, step name: {}, status: {}", stepExecution.getStepName(),
+                    stepExecution.getStatus());
+            log.info(
+                    "StepExecutionListener - ReadCount: {}, WriteCount: {}, FilterCount: {}, ReadSkipCount: {}, ProcessSkipCount: {}, WriteSkipCount: {}",
+                    stepExecution.getReadCount(), stepExecution.getWriteCount(), stepExecution.getFilterCount(),
+                    stepExecution.getReadSkipCount(), stepExecution.getProcessSkipCount(),
+                    stepExecution.getWriteSkipCount());
+            return StepExecutionListener.super.afterStep(stepExecution);
+        }
+    }
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
@@ -1,7 +1,7 @@
 package com.kernel360.modulebatch.product.job.core;
 
 import com.kernel360.brand.entity.Brand;
-import com.kernel360.modulebatch.product.job.JpaProductListWriter;
+import com.kernel360.modulebatch.product.job.infra.JpaProductListWriter;
 import com.kernel360.modulebatch.product.job.infra.ConcernedProductToProductListItemProcessor;
 import com.kernel360.product.entity.Product;
 import jakarta.persistence.EntityManagerFactory;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromConcernedProductJobConfig.java
@@ -1,6 +1,7 @@
-package com.kernel360.modulebatch.product.job;
+package com.kernel360.modulebatch.product.job.core;
 
 import com.kernel360.brand.entity.Brand;
+import com.kernel360.modulebatch.product.job.infra.JpaProductListWriter;
 import com.kernel360.modulebatch.product.job.infra.ConcernedProductToProductListItemProcessor;
 import com.kernel360.product.entity.Product;
 import jakarta.persistence.EntityManagerFactory;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromReportedProductJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/core/ImportProductFromReportedProductJobConfig.java
@@ -4,7 +4,7 @@ import com.kernel360.brand.entity.Brand;
 import com.kernel360.ecolife.entity.ReportedProduct;
 import com.kernel360.ecolife.repository.ReportedProductRepository;
 import com.kernel360.modulebatch.product.dto.ProductDto;
-import com.kernel360.modulebatch.product.job.JpaProductListWriter;
+import com.kernel360.modulebatch.product.job.infra.JpaProductListWriter;
 import com.kernel360.product.entity.Product;
 import com.kernel360.product.entity.SafetyStatus;
 import com.kernel360.product.repository.ProductRepository;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ConcernedProductToProductListItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ConcernedProductToProductListItemProcessor.java
@@ -1,0 +1,150 @@
+package com.kernel360.modulebatch.product.job.infra;
+
+import com.kernel360.brand.entity.Brand;
+import com.kernel360.ecolife.entity.ConcernedProduct;
+import com.kernel360.ecolife.repository.ConcernedProductRepository;
+import com.kernel360.modulebatch.product.dto.ProductDto;
+import com.kernel360.product.entity.Product;
+import com.kernel360.product.entity.SafetyStatus;
+import com.kernel360.product.repository.ProductRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ConcernedProductToProductListItemProcessor implements ItemProcessor<Brand, List<Product>> {
+
+    private final ConcernedProductRepository concernedProductRepository;
+
+    private final ProductRepository productRepository;
+
+    @Override
+    public List<Product> process(Brand brand) throws Exception {
+        List<ConcernedProduct> concernedProductList = concernedProductRepository
+                .findByBrandNameAndCompanyName(
+                        "%" + brand.getBrandName().replaceAll(" ", "%") + "%",
+                        "%" + brand.getCompanyName().replaceAll(" ", "%") + "%");
+
+        List<ProductDto> productDtoList = concernedProductList.stream()
+                                                              .filter(cp -> cp.getInspectedOrganization() != null)
+                                                              .map(cp -> ProductDto.of(cp.getProductName(),
+                                                                      null,
+                                                                      null,
+                                                                      "취하".equals(cp.getProductType())
+                                                                              ? SafetyStatus.DANGER
+                                                                              : SafetyStatus.CONCERN,
+                                                                      0,
+                                                                      cp.getCompanyName(),
+                                                                      cp.getReportNumber(),
+                                                                      cp.getProductType(),
+                                                                      LocalDate.from(cp.getIssuedDate()),
+                                                                      cp.getSafetyInspectionStandard(),
+                                                                      cp.getUpperItem(),
+                                                                      cp.getItem(),
+                                                                      null,
+                                                                      null,
+                                                                      null,
+                                                                      null, null, null, null,
+                                                                      null, null, null, null,
+                                                                      cp.getManufacture(), null,
+                                                                      cp.getManufactureNation(),
+                                                                      brand))
+                                                              .toList();
+
+        return convertToProductList(productDtoList);
+    }
+
+    private List<Product> convertToProductList(List<ProductDto> productDtoList) {
+        List<Product> productList = new ArrayList<>();
+
+        for (ProductDto productDto : productDtoList) {
+            Optional<Product> foundProduct = productRepository.findProductByProductNameAndCompanyName(
+                    productDto.productName(), "%" + getCompanyNameWithoutSlash(productDto.companyName()) + "%");
+
+            boolean foundInList = productList.stream().anyMatch(
+                    product -> product.getProductName().equals(productDto.productName()) &&
+                            product.getCompanyName().equals(productDto.companyName()));
+
+            if (foundInList) { // 현재 처리할 데이터에 이미 추가가 되어 있다면 무시
+                continue;
+            }
+
+            if (foundProduct.isEmpty()) {
+                Product newProduct = generateNewProduct(productDto);
+                productList.add(newProduct);
+                continue;
+            }
+
+            if (productDto.issuedDate().isAfter(foundProduct.get().getIssuedDate())) { // 저장된 데이터보다 최신의 제품 데이터라면
+                foundProduct.get().updateDetail(productDto.barcode(),
+                        productDto.imageSource(),
+                        productDto.reportNumber(),
+                        String.valueOf(productDto.safetyStatus()),
+                        productDto.issuedDate(),
+                        productDto.safetyInspectionStandard(),
+                        productDto.upperItem(),
+                        productDto.item(),
+                        productDto.propose(),
+                        productDto.weight(),
+                        productDto.usage(),
+                        productDto.usagePrecaution(),
+                        productDto.firstAid(),
+                        productDto.mainSubstance(),
+                        productDto.allergicSubstance(),
+                        productDto.otherSubstance(),
+                        productDto.preservative(),
+                        productDto.surfactant(),
+                        productDto.fluorescentWhitening(),
+                        productDto.manufactureType(),
+                        productDto.manufactureMethod(),
+                        getNation(productDto),
+                        productDto.brand());
+            }
+        }
+
+        return productList;
+    }
+
+    private static Product generateNewProduct(ProductDto productDto) {
+
+        return Product.of(productDto.productName(), productDto.barcode(),
+                productDto.imageSource(), productDto.reportNumber(), String.valueOf(productDto.safetyStatus()),
+                productDto.viewCount(), getCompanyNameWithoutSlash(productDto.companyName()), productDto.productType(),
+                productDto.issuedDate(), productDto.safetyInspectionStandard(), productDto.upperItem(),
+                productDto.item(), productDto.propose(), productDto.weight(), productDto.usage(),
+                productDto.usagePrecaution(), productDto.firstAid(), productDto.mainSubstance(),
+                productDto.allergicSubstance(), productDto.otherSubstance(), productDto.preservative(),
+                productDto.surfactant(), productDto.fluorescentWhitening(), productDto.manufactureType(),
+                productDto.manufactureMethod(), getNation(productDto), productDto.brand());
+    }
+
+    public static String getCompanyNameWithoutSlash(String companyName) {
+        int index = companyName.indexOf("/");
+        if (index != -1) {
+            return companyName.substring(0, index);
+        }
+        return companyName;
+
+    }
+
+    private static String getNation(ProductDto productDto) {
+        String nation;
+        if (productDto.manufactureType().equals("수입")) {
+            nation = productDto.brand().getNationName();
+        } else {
+            nation = "대한민국";
+        }
+        return nation;
+    }
+
+
+}

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/JpaProductListWriter.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/JpaProductListWriter.java
@@ -1,4 +1,4 @@
-package com.kernel360.modulebatch.product.job;
+package com.kernel360.modulebatch.product.job.infra;
 
 import java.util.List;
 import org.springframework.batch.item.Chunk;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/client/ReportedProductClient.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/client/ReportedProductClient.java
@@ -2,6 +2,7 @@ package com.kernel360.modulebatch.reportedproduct.client;
 
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -11,7 +12,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Slf4j
 @Component
 public class ReportedProductClient implements ApiClient<Integer> {
-    private static final String AUTH_KEY = System.getenv("API_AUTH_KEY");
+
+    @Value("${external.ecolife-api.path}")
+    private String BASE_PATH;
+
+    @Value("${external.ecolife-api.service-key}")
+    private String AUTH_KEY;
 
     private final RestClient restClient;
 
@@ -60,7 +66,7 @@ public class ReportedProductClient implements ApiClient<Integer> {
 
     public String buildUri(Integer pageNumber) {
 
-        return UriComponentsBuilder.fromHttpUrl("https://ecolife.me.go.kr/openapi/ServiceSvl")
+        return UriComponentsBuilder.fromHttpUrl(BASE_PATH)
                                    .queryParam("AuthKey", AUTH_KEY)
                                    .queryParam("ServiceName", "slfsfcfst02List")
                                    .queryParam("PageCount", "20")

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/client/ReportedProductDetailClient.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/client/ReportedProductDetailClient.java
@@ -3,6 +3,7 @@ package com.kernel360.modulebatch.reportedproduct.client;
 import com.kernel360.ecolife.entity.ReportedProduct;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class ReportedProductDetailClient implements ApiClient<ReportedProduct> {
 
-    private static final String AUTH_KEY = System.getenv("API_AUTH_KEY");
+    @Value("${external.ecolife-api.path}")
+    private String BASE_PATH;
+
+    @Value("${external.ecolife-api.service-key}")
+    private String AUTH_KEY;
 
     private final RestClient restClient;
 
@@ -56,7 +61,7 @@ public class ReportedProductDetailClient implements ApiClient<ReportedProduct> {
     @Override
     public String buildUri(ReportedProduct reportedProduct) {
 
-        return UriComponentsBuilder.fromHttpUrl("https://ecolife.me.go.kr/openapi/ServiceSvl")
+        return UriComponentsBuilder.fromHttpUrl(BASE_PATH)
                                    .queryParam("AuthKey", AUTH_KEY)
                                    .queryParam("ServiceName", "slfsfcfst02Detail")
                                    .queryParam("mstId", reportedProduct.getId().getProductMasterId())

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/client/ReportedProductFromBrandClient.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/client/ReportedProductFromBrandClient.java
@@ -3,6 +3,7 @@ package com.kernel360.modulebatch.reportedproduct.client;
 import com.kernel360.brand.entity.Brand;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class ReportedProductFromBrandClient{
 
-    private static final String AUTH_KEY = System.getenv("API_AUTH_KEY");
+    @Value("${external.ecolife-api.path}")
+    private String BASE_PATH;
+
+    @Value("${external.ecolife-api.service-key}")
+    private String AUTH_KEY;
 
     private final RestClient restClient;
 
@@ -55,7 +60,7 @@ public class ReportedProductFromBrandClient{
 
 
     public String buildUri(Brand brand, int pageNumber) {
-        return UriComponentsBuilder.fromHttpUrl("https://ecolife.me.go.kr/openapi/ServiceSvl")
+        return UriComponentsBuilder.fromHttpUrl(BASE_PATH)
                                    .queryParam("AuthKey", AUTH_KEY)
                                    .queryParam("ServiceName", "slfsfcfst02List")
                                    .queryParam("PageCount", "20")

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/core/ReportedProductApiJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/core/ReportedProductApiJobConfig.java
@@ -1,7 +1,9 @@
-package com.kernel360.modulebatch.reportedproduct.job;
+package com.kernel360.modulebatch.reportedproduct.job.core;
 
 import com.kernel360.modulebatch.reportedproduct.dto.ReportedProductDto;
-import com.kernel360.modulebatch.reportedproduct.service.ReportedProductService;
+import com.kernel360.modulebatch.reportedproduct.job.infra.ReportedProductListItemReader;
+import com.kernel360.modulebatch.reportedproduct.job.infra.ReportedProductListItemWriter;
+import com.kernel360.modulebatch.reportedproduct.job.RetryReportedProductListItemReader;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,7 +11,6 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
@@ -18,6 +19,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.ResourceAccessException;
 
@@ -26,7 +28,11 @@ import org.springframework.web.client.ResourceAccessException;
 @RequiredArgsConstructor
 public class ReportedProductApiJobConfig {
 
-    private final ReportedProductService service;
+    private final ReportedProductListItemReader reportedProductListItemReader;
+
+    private final ReportedProductListItemWriter reportedProductListItemWriter;
+
+    private final RetryTemplate retryTemplate;
 
     @Bean
     public Job fetchReportedProductJob(JobRepository jobRepository,
@@ -45,28 +51,18 @@ public class ReportedProductApiJobConfig {
     public Step fetchReportedProductListStep(JobRepository jobRepository,
                                              PlatformTransactionManager transactionManager) {
         log.info("Fetch ReportedProduct List Step Build Configuration");
+
         return new StepBuilder("fetchReportedProductListStep", jobRepository)
                 .<List<ReportedProductDto>, List<ReportedProductDto>>chunk(10, transactionManager)
-                .reader(productListItemReader()) // API 요청, 응답을 DTO 리스트로 반환
-                .writer(productListItemWriter()) // DTO 리스트 입력, 저장
+                .reader(new RetryReportedProductListItemReader(reportedProductListItemReader,
+                        retryTemplate)) // API 요청, 응답을 DTO 리스트로 반환
+                .writer(reportedProductListItemWriter) // DTO 리스트 입력, 저장
                 .faultTolerant()
                 .retryLimit(2)
                 .retry(ResourceAccessException.class)
                 .skipLimit(10)
                 .skip(DataIntegrityViolationException.class)
                 .build();
-    }
-
-    @Bean
-    @StepScope
-    public ReportedProductListItemReader productListItemReader() {
-        return new ReportedProductListItemReader(service);
-    }
-
-    @Bean
-    @StepScope
-    public ReportedProductListItemWriter productListItemWriter() {
-        return new ReportedProductListItemWriter(service);
     }
 
     //-- Execution Listener --//
@@ -82,6 +78,5 @@ public class ReportedProductApiJobConfig {
             log.info("{} ends", jobExecution.getJobInstance().getJobName());
         }
     }
-
 
 }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/core/ReportedProductApiJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/core/ReportedProductApiJobConfig.java
@@ -3,7 +3,6 @@ package com.kernel360.modulebatch.reportedproduct.job.core;
 import com.kernel360.modulebatch.reportedproduct.dto.ReportedProductDto;
 import com.kernel360.modulebatch.reportedproduct.job.infra.ReportedProductListItemReader;
 import com.kernel360.modulebatch.reportedproduct.job.infra.ReportedProductListItemWriter;
-import com.kernel360.modulebatch.reportedproduct.job.RetryReportedProductListItemReader;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +18,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.ResourceAccessException;
 
@@ -32,7 +30,6 @@ public class ReportedProductApiJobConfig {
 
     private final ReportedProductListItemWriter reportedProductListItemWriter;
 
-    private final RetryTemplate retryTemplate;
 
     @Bean
     public Job fetchReportedProductJob(JobRepository jobRepository,
@@ -54,8 +51,7 @@ public class ReportedProductApiJobConfig {
 
         return new StepBuilder("fetchReportedProductListStep", jobRepository)
                 .<List<ReportedProductDto>, List<ReportedProductDto>>chunk(10, transactionManager)
-                .reader(new RetryReportedProductListItemReader(reportedProductListItemReader,
-                        retryTemplate)) // API 요청, 응답을 DTO 리스트로 반환
+                .reader(reportedProductListItemReader) // API 요청, 응답을 DTO 리스트로 반환
                 .writer(reportedProductListItemWriter) // DTO 리스트 입력, 저장
                 .faultTolerant()
                 .retryLimit(2)

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/core/ReportedProductDetailApiJobConfig.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/core/ReportedProductDetailApiJobConfig.java
@@ -1,7 +1,7 @@
-package com.kernel360.modulebatch.reportedproduct.job;
+package com.kernel360.modulebatch.reportedproduct.job.core;
 
 import com.kernel360.ecolife.entity.ReportedProduct;
-import com.kernel360.modulebatch.reportedproduct.service.ReportedProductService;
+import com.kernel360.modulebatch.reportedproduct.job.infra.ReportedProductDetailItemProcessor;
 import jakarta.persistence.EntityManagerFactory;
 import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
@@ -29,7 +29,8 @@ import org.springframework.web.client.ResourceAccessException;
 @Configuration
 @RequiredArgsConstructor
 public class ReportedProductDetailApiJobConfig {
-    private final ReportedProductService service;
+
+    private final ReportedProductDetailItemProcessor reportedProductDetailItemProcessor;
 
     private final EntityManagerFactory emf;
 
@@ -51,7 +52,7 @@ public class ReportedProductDetailApiJobConfig {
         return new StepBuilder("fetchReportedProductDetailStep", jobRepository)
                 .<ReportedProduct, ReportedProduct>chunk(10, transactionManager)
                 .reader(productDetailItemReader()) // reported_product 테이블 읽어서 엔티티를 전달
-                .processor(productDetailItemProcessor()) // 전달받은 엔티티로 detail 조회, 엔티티로 변환
+                .processor(reportedProductDetailItemProcessor) // 전달받은 엔티티로 detail 조회, 엔티티로 변환
                 .writer(productDetailJpaItemWriter(emf)) // 엔티티를 테이블에 업데이트
                 .faultTolerant()
                 .retryLimit(2)
@@ -72,12 +73,6 @@ public class ReportedProductDetailApiJobConfig {
         reader.setPageSize(1000);
 
         return reader;
-    }
-
-    @Bean
-    @StepScope
-    public ReportedProductDetailItemProcessor productDetailItemProcessor() {
-        return new ReportedProductDetailItemProcessor(service);
     }
 
     @Bean

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/FetchReportedProductListFromBrandItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/FetchReportedProductListFromBrandItemProcessor.java
@@ -1,4 +1,4 @@
-package com.kernel360.modulebatch.reportedproduct.job;
+package com.kernel360.modulebatch.reportedproduct.job.infra;
 
 import com.kernel360.brand.entity.Brand;
 import com.kernel360.modulebatch.reportedproduct.client.ReportedProductFromBrandClient;
@@ -10,9 +10,13 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
+@StepScope
 @RequiredArgsConstructor
 public class FetchReportedProductListFromBrandItemProcessor implements ItemProcessor<Brand, List<ReportedProductDto>> {
 

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/ReportedProductDetailItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/ReportedProductDetailItemProcessor.java
@@ -1,4 +1,4 @@
-package com.kernel360.modulebatch.reportedproduct.job;
+package com.kernel360.modulebatch.reportedproduct.job.infra;
 
 import com.kernel360.ecolife.entity.ReportedProduct;
 import com.kernel360.modulebatch.reportedproduct.client.ReportedProductDetailClient;
@@ -9,8 +9,10 @@ import java.time.format.DateTimeFormatter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
 public class ReportedProductDetailItemProcessor implements ItemProcessor<ReportedProduct, ReportedProduct> {
     private final ReportedProductService service;
     private final ReportedProductDetailClient client;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/ReportedProductListItemReader.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/ReportedProductListItemReader.java
@@ -1,4 +1,4 @@
-package com.kernel360.modulebatch.reportedproduct.job;
+package com.kernel360.modulebatch.reportedproduct.job.infra;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.kernel360.modulebatch.reportedproduct.client.ReportedProductClient;
@@ -7,9 +7,13 @@ import com.kernel360.modulebatch.reportedproduct.service.ReportedProductService;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemReader;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
+@StepScope
 public class ReportedProductListItemReader implements ItemReader<List<ReportedProductDto>> {
 
     private static int MAX_PAGES_PER_JOB;

--- a/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/ReportedProductListItemWriter.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/reportedproduct/job/infra/ReportedProductListItemWriter.java
@@ -1,17 +1,21 @@
-package com.kernel360.modulebatch.reportedproduct.job;
+package com.kernel360.modulebatch.reportedproduct.job.infra;
 
 import com.kernel360.modulebatch.reportedproduct.dto.ReportedProductDto;
 import com.kernel360.modulebatch.reportedproduct.service.ReportedProductService;
 import java.util.List;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
 
+@Component
+@StepScope
 public class ReportedProductListItemWriter implements ItemWriter<List<ReportedProductDto>> {
 
-    private final ReportedProductService apiService;
+    private final ReportedProductService service;
 
-    public ReportedProductListItemWriter(ReportedProductService apiService) {
-        this.apiService = apiService;
+    public ReportedProductListItemWriter(ReportedProductService service) {
+        this.service = service;
     }
 
     /**
@@ -23,7 +27,7 @@ public class ReportedProductListItemWriter implements ItemWriter<List<ReportedPr
     public void write(Chunk<? extends List<ReportedProductDto>> chunk) throws Exception {
         for (List<ReportedProductDto> c : chunk) {
             for (ReportedProductDto reportedProductDto : c) {
-                apiService.saveReportedProduct(reportedProductDto);
+                service.saveReportedProduct(reportedProductDto);
             }
         }
     }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/scheduler/ConcernedProductScheduler.java
@@ -18,16 +18,19 @@ import org.springframework.stereotype.Component;
 public class ConcernedProductScheduler {
     private final Job fetchConcernedProductListFromBrandJob;
     private final Job fetchConcernedProductDetailJob;
+    private final Job importProductFromConcernedProductJob;
     private final JobLauncher jobLauncher;
 
     @Autowired
     public ConcernedProductScheduler(
             @Qualifier("fetchConcernedProductListFromBrandJob") Job fetchConcernedProductListJob,
             @Qualifier("fetchConcernedProductDetailJob") Job fetchConcernedProductDetailJob,
+            @Qualifier("importProductFromConcernedProductJob") Job importProductFromConcernedProductJob,
             JobLauncher jobLauncher) {
 
         this.fetchConcernedProductListFromBrandJob = fetchConcernedProductListJob;
         this.fetchConcernedProductDetailJob = fetchConcernedProductDetailJob;
+        this.importProductFromConcernedProductJob = importProductFromConcernedProductJob;
         this.jobLauncher = jobLauncher;
     }
 
@@ -45,6 +48,14 @@ public class ConcernedProductScheduler {
     @Scheduled(cron = "0 30 19 * * THU", zone = "Asia/Seoul")
     public void executeFetchConcernedProductDetailJob() {
         executeJob(fetchConcernedProductDetailJob);
+    }
+
+    /**
+     * 매주 목요일 20시 00분 실행
+     */
+    @Scheduled(cron = "0 0 20 * * THU", zone = "Asia/Seoul")
+    public void executeImportProductFromConcernedProductJob() {
+        executeJob(importProductFromConcernedProductJob);
     }
 
     private synchronized void executeJob(Job job) {

--- a/module-batch/src/test/java/com/kernel360/modulebatch/job/ReportedProductApiJobConfigTest.java
+++ b/module-batch/src/test/java/com/kernel360/modulebatch/job/ReportedProductApiJobConfigTest.java
@@ -2,7 +2,7 @@ package com.kernel360.modulebatch.job;
 
 import static org.mockito.Mockito.mock;
 
-import com.kernel360.modulebatch.reportedproduct.job.ReportedProductApiJobConfig;
+import com.kernel360.modulebatch.reportedproduct.job.core.ReportedProductApiJobConfig;
 import com.kernel360.modulebatch.reportedproduct.service.ReportedProductService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;

--- a/module-domain/src/main/java/com/kernel360/ecolife/repository/ConcernedProductRepository.java
+++ b/module-domain/src/main/java/com/kernel360/ecolife/repository/ConcernedProductRepository.java
@@ -1,7 +1,19 @@
 package com.kernel360.ecolife.repository;
 
 import com.kernel360.ecolife.entity.ConcernedProduct;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-public interface ConcernedProductRepository extends JpaRepository<ConcernedProduct,String> {
+@Repository
+public interface ConcernedProductRepository extends JpaRepository<ConcernedProduct, String> {
+    @Query(value = "SELECT cp.* FROM concerned_product cp "
+            + "JOIN LATERAL (SELECT cp2.prdt_name, MAX(cp2.issued_date) AS max_issu_date "
+            + "FROM concerned_product cp2 WHERE cp2.comp_nm LIKE :companyName AND cp2.prdt_name LIKE :brandName GROUP BY cp2.prdt_name) max_dates "
+            + "ON cp.prdt_name = max_dates.prdt_name AND cp.issued_date = max_dates.max_issu_date "
+            + "ORDER BY max_dates.max_issu_date DESC", nativeQuery = true)
+    List<ConcernedProduct> findByBrandNameAndCompanyName(@Param("brandName") String brandName,
+                                                         @Param("companyName") String companyName);
 }

--- a/module-domain/src/main/java/com/kernel360/product/repository/ProductRepository.java
+++ b/module-domain/src/main/java/com/kernel360/product/repository/ProductRepository.java
@@ -26,6 +26,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query(value = "SELECT p FROM Product p WHERE p.productName = :productName "
             + "AND p.companyName like :companyName")
-    Optional<Product> findProductByProductNameAndReportNumber(@Param("productName") String productName,
-                                                              @Param("companyName") String companyName);
+    Optional<Product> findProductByProductNameAndCompanyName(@Param("productName") String productName,
+                                                             @Param("companyName") String companyName);
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`배치 모듈 하위의 클래스들을 적절한 디렉터리로 분리하여 가독성을 높였습니다`

<br>

## 🔨 Modified
> job 하위의 클래스들을 core와 infra 로 구분하였습니다
  - _jobconfig 파일은 core, 그외 itemreader 등은 infra로 디렉터리를 지정합니다_

<br>

## 🌟 More
- _중복 코드 등 추가적인 리팩토링 작업이 필요합니다_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #101
