### PR TITLE
chore ::  MYBATIS ORM 추가

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 
     //prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    //mybatis
+    implementation group: 'org.mybatis.spring.boot', name: 'mybatis-spring-boot-starter', version: '3.0.3'
 }
 
 tasks.named('test') {

--- a/module-api/src/main/java/com/kernel360/commoncode/controller/CommonCodeController.java
+++ b/module-api/src/main/java/com/kernel360/commoncode/controller/CommonCodeController.java
@@ -1,9 +1,9 @@
 package com.kernel360.commoncode.controller;
 
-import com.kernel360.commoncode.service.CommonCodeService;
 import com.kernel360.commoncode.dto.CommonCodeDto;
+import com.kernel360.commoncode.service.CommonCodeService;
 import com.kernel360.response.ApiResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,25 +15,13 @@ import java.util.List;
 import static com.kernel360.commoncode.code.CommonCodeBusinessCode.GET_COMMON_CODE_SUCCESS;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/commoncode")
 public class CommonCodeController {
 
-    final CommonCodeService commonCodeService;
-
-    @Autowired
-    public CommonCodeController(CommonCodeService commonCodeService) {
-        this.commonCodeService = commonCodeService;
-    }
-
+    private final CommonCodeService commonCodeService;
     @GetMapping("/{codeName}")
-    public List<CommonCodeDto> getCommonCode (@PathVariable String codeName){
-
-        return commonCodeService.getCodes(codeName);
-    }
-
-    // FIXME :: 아래 메서드는 추후 삭제 예정입니다
-    @GetMapping("/test/{codeName}")
-    public ResponseEntity<ApiResponse<List<CommonCodeDto>>> getCommonCode_1 (@PathVariable String codeName){
+    public ResponseEntity<ApiResponse<List<CommonCodeDto>>> getCommonCode (@PathVariable String codeName){
         List<CommonCodeDto> codes = commonCodeService.getCodes(codeName);
 
         return ApiResponse.toResponseEntity(GET_COMMON_CODE_SUCCESS, codes);

--- a/module-api/src/main/java/com/kernel360/commoncode/service/CommonCodeService.java
+++ b/module-api/src/main/java/com/kernel360/commoncode/service/CommonCodeService.java
@@ -1,25 +1,31 @@
 package com.kernel360.commoncode.service;
 
 import com.kernel360.commoncode.dto.CommonCodeDto;
+import com.kernel360.commoncode.mapper.CommonCodeMapper;
 import com.kernel360.commoncode.repository.CommonCodeRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class CommonCodeService {
 
-    final CommonCodeRepository commonCodeRepository;
-
-    @Autowired
-    public CommonCodeService(CommonCodeRepository commonCodeRepository) {
-        this.commonCodeRepository = commonCodeRepository;
-    }
+    private final CommonCodeRepository commonCodeRepository;
+    private final CommonCodeMapper commonCodeMapper;
 
     public List<CommonCodeDto> getCodes(String codeName) {
 
         return commonCodeRepository.findAllByUpperNameAndIsUsed(codeName,true)
+                                   .stream()
+                                   .map(CommonCodeDto::from)
+                                   .toList();
+    }
+
+    public List<CommonCodeDto> getCodesMapper(String codeName) {
+
+        return commonCodeMapper.findAllByUpperNameAndIsUsed(codeName,true)
                                    .stream()
                                    .map(CommonCodeDto::from)
                                    .toList();

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -33,18 +33,14 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-    private final WashInfoRepository washInfoRepository;
-    private final CarInfoRepository carInfoRepository;
 
     private final JWT jwt;
     private final AuthRepository authRepository;
     private final MemberRepository memberRepository;
     private final CommonCodeService commonCodeService;
+    private final CarInfoRepository carInfoRepository;
+    private final WashInfoRepository washInfoRepository;
 
-
-    /**
-     * 가입
-     **/
     @Transactional
     public void joinMember(MemberDto requestDto) {
 
@@ -72,9 +68,6 @@ public class MemberService {
         return Member.createJoinMember(requestDto.id(), requestDto.email(), encodePassword, genderOrdinal, ageOrdinal);
     }
 
-    /**
-     * 로그인
-     **/
     @Transactional
     public MemberDto login(MemberDto loginDto) {
 

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation group: 'org.mybatis.spring.boot', name: 'mybatis-spring-boot-starter', version: '3.0.3'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 }

--- a/module-domain/src/main/java/com/kernel360/commoncode/mapper/CommonCodeMapper.java
+++ b/module-domain/src/main/java/com/kernel360/commoncode/mapper/CommonCodeMapper.java
@@ -1,0 +1,30 @@
+package com.kernel360.commoncode.mapper;
+
+import com.kernel360.commoncode.entity.CommonCode;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface CommonCodeMapper {
+    /** 애노테이션으로 맵핑이 보기 싫다면 xml로 따로 빼면 됩니다. **/
+    @Results(id = "CommonCodeVO", value={
+            @Result(property = "codeNo", column = "code_no"),
+            @Result(property = "codeName", column = "code_name"),
+            @Result(property = "upperNo", column = "upper_no"),
+            @Result(property = "upperName", column = "upper_name"),
+            @Result(property = "sortOrder", column = "sort_order"),
+            @Result(property = "isUsed", column = "is_used"),
+            @Result(property = "description", column = "description"),
+            @Result(property = "subDescription", column = "sub_description"),
+            @Result(property = "createdAt", column = "created_at"),
+            @Result(property = "createdBy", column = "created_by"),
+            @Result(property = "modifiedAt", column = "modified_at"),
+            @Result(property = "modifiedBy", column = "modified_by")
+    })
+    @Select("SELECT * FROM common_code WHERE upper_name = #{codeName} and is_used = #{isUsed}")
+    List<CommonCode> findAllByUpperNameAndIsUsed(String codeName, boolean isUsed);
+}

--- a/module-domain/src/main/java/com/kernel360/commoncode/vo/CommonCodeVO.java
+++ b/module-domain/src/main/java/com/kernel360/commoncode/vo/CommonCodeVO.java
@@ -1,0 +1,42 @@
+package com.kernel360.commoncode.vo;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommonCodeVO {
+    private Long codeNo;
+
+    private String codeName;
+
+    private Integer upperNo;
+
+    private String upperName;
+
+    private Integer sortOrder;
+
+    private Boolean isUsed = false;
+
+    private String description;
+
+    private String subDescription;
+
+    private LocalDate createdAt;
+
+    private String createdBy;
+
+    private LocalDate modifiedAt;
+
+    private String modifiedBy;
+
+    //TODO BUILDER -> RETURN NEW PATTERN
+    @Builder
+    public CommonCodeVO(Integer codeNo, String codeName, Integer upperNo, String upperName, Integer sortOrder, Boolean isUsed, String description, String subDescription, LocalDate createdAt, String createdBy, LocalDate modifiedAt, String modifiedBy) {
+
+    }
+}

--- a/module-domain/src/main/java/com/kernel360/config/MybatisConfig.java
+++ b/module-domain/src/main/java/com/kernel360/config/MybatisConfig.java
@@ -1,0 +1,32 @@
+package com.kernel360.config;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class MybatisConfig {
+    @Bean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
+        sqlSessionFactoryBean.setDataSource(dataSource);
+
+        return sqlSessionFactoryBean.getObject();
+    }
+
+    @Bean
+    public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory){
+        return new SqlSessionTemplate(sqlSessionFactory);
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(DataSource dataSource){
+        return new DataSourceTransactionManager(dataSource);
+    }
+}


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
 - 모듈을 분리하지않고 mybatis를 추가하였습니다.

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - _여기에 세부 변경사항을 설명해주세요_

 - mapper를 사용하고자 한다면 모듈api의 service에서 mapper를 추가 후 모듈 domain에서 vo와 mapper를 추가하면 됩니다.
 - 
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/9fbd02dd-d5b8-42a0-95bf-6224db02346b)
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/d733fdd0-fb2b-4b2d-a86c-832f38017a49)


<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

- 모듈 api 및 모듈 domain의 역할을 생각해보건 바, api에선 ORM관련 의존성이 없어야 맞다고 판단되어 제거를 시도했습니다만 실패했습니다. (이유는 아랫문단)

- ORM.java를 추가하여 repository 호출을 별도로 분리하려 하였으나, static 관련 에러가 발생함에 따라 이 부분은 적용하지 않았습니다. 이전 작업시 infra 모듈을 썼을땐 이 문제가 발생하지 않았던걸로 기억하는데 무엇이 원인인지는 아직 알 수 없습니다.
 
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/f53abaa3-0308-48b9-b01e-2074911b8edb)

- ~~member 서비스 코드 리팩토링 이후 그래도 지저분하다면 필요에 따라 추가 개선을 할 예정입니다.~~ 
- -> module-infra 나눴던 리포지터리로 memberService 옮겨본 결과, controller의 대한 에러코드, service의 대한 에러코드까지 상세하게 다시 작업해야 합니다. 
- 모듈 독립으로 인해 리포지터리 모킹을 안하고 store, reader 객체를 모킹해서 성공데이터를 받는 형식으로 짜게되므로 테스트코드 난이도가 줄겠지만, 결국은 다시 작성해야 합니다. 
- 작업 규모가 리팩토링 수준이 아닌 고도화 수준입니다.
- 연습삼아 해보실분은 개인 리포를 삭제하지 않고 남겨둘테니 그걸 쓰시면 됩니다.
<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #126 #117 
