### PR TITLE
[Hotfix] 사용하지 않는 제품을 product 테이블에서 삭제하는 작업 추가

### DIFF
--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/FilterUnusedProductTasklet.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/FilterUnusedProductTasklet.java
@@ -18,8 +18,8 @@ public class FilterUnusedProductTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        jdbcTemplate.update("delete from product where upper_item like '%세탁%'");
-        jdbcTemplate.update("delete from product where product_name similar to '(방향제|그라스|통풍구|선바이저|살라딘|세탁|체인)%'");
+        jdbcTemplate.update("delete from product where product.upper_item like '%세탁%'");
+        jdbcTemplate.update("delete from product where product.product_name similar to '%(방향제|그라스|통풍구|선바이저|살라딘|세탁|체인)%'");
 
         return RepeatStatus.FINISHED;
     }

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/FilterUnusedProductTasklet.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/FilterUnusedProductTasklet.java
@@ -1,0 +1,26 @@
+package com.kernel360.modulebatch.product.job.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class FilterUnusedProductTasklet implements Tasklet {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        jdbcTemplate.update("delete from product where upper_item like '%세탁%'");
+        jdbcTemplate.update("delete from product where product_name similar to '(방향제|그라스|통풍구|선바이저|살라딘|세탁|체인)%'");
+
+        return RepeatStatus.FINISHED;
+    }
+}


### PR DESCRIPTION
## 💡 Motivation and Context
`서비스 목적과 맞지 않는 제품들이 서비스 테이블에 포함되어 있는 문제가 발견되었고, 이를 배치 작업을 수행할 때 필터링을 수행함으로써 서비스 테이블에 포함하지 않도록 변경하였습니다.`

<br>

## 🔨 Modified
> 사용하지 않는 제품을 product 테이블에서 삭제시키는 Step 추가
    
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/c63af60a-7eaf-4de7-ac29-fc0602aeb8cf)

![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/ad2ed26a-f31a-45e0-a53f-bf97e53ad434)

  - _feat :: 사용하지 않는 제품을 product 테이블에서 삭제시키는 쿼리를 직접 수행하는 Tasklet 추가_
    
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/61f9fba6-e2e8-47bd-a5cf-89f6adca3047)
<br>

## 🌟 More
- _하드 코딩 되어 있습니다. 다른 배치 작업에서도 수행할 필요가 있을 때, Step을 별도의 클래스로 구분하는 리팩터링 작업이 추가로 필요합니다._
- _약 2800 개에서 2500 여개의 제품으로 필터링 되는 것을 확인하였습니다._

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
