### PR TITLE
Feature : 가입시 입력한 이메일로 분실한 회원 아이디를 발송하는 기능

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -61,6 +61,8 @@ jobs:
           spring.datasource.password: ${{ secrets.DB_PW }}
           external.ecolife-api.path: ${{ secrets.ECOLIFE_PATH }}
           external.ecolife-api.service-key: ${{ secrets.ECOLIFE_KEY }}
+          spring.mail.username: ${{ secrets.SMTP_GOOGLE_EMAIL }}
+          spring.mail.password: ${{ secrets.SMTP_PASSWORD }}
 
       - name: Grant execute permission And Build with Gradle (api)
         working-directory: ./module-api

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -43,6 +43,8 @@ jobs:
           spring.datasource.url: ${{ secrets.DB_URL_AWS }}
           spring.datasource.username: ${{ secrets.DB_USER }}
           spring.datasource.password: ${{ secrets.DB_PW }}
+          spring.mail.username: ${{ secrets.SMTP_GOOGLE_EMAIL }}
+          spring.mail.password: ${{ secrets.SMTP_PASSWORD }}
 
       - name: Grant execute permission And Build with Gradle (api)
         working-directory: ./module-api

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'

--- a/module-api/src/main/java/com/kernel360/member/code/MemberBusinessCode.java
+++ b/module-api/src/main/java/com/kernel360/member/code/MemberBusinessCode.java
@@ -16,7 +16,8 @@ public enum MemberBusinessCode implements BusinessCode {
     SUCCESS_REQUEST_CHANGE_PASSWORD_MEMBER(HttpStatus.OK.value(), "BMC007", "비밀번호가 변경 되었습니다."),
     SUCCESS_VALIDATE_PASSWORD_MEMBER(HttpStatus.OK.value(), "BMC008", "비밀번호가 확인 되었습니다."),
     SUCCESS_REQUEST_UPDATE_WASH_INFO_MEMBER(HttpStatus.OK.value(), "BMC009", "WashInfo 정보가 변경 되었습니다."),
-    SUCCESS_REQUEST_UPDATE_CAR_INFO_MEMBER(HttpStatus.OK.value(), "BMC010", "CarInfo 정보가 변경 되었습니다.");
+    SUCCESS_REQUEST_UPDATE_CAR_INFO_MEMBER(HttpStatus.OK.value(), "BMC010", "CarInfo 정보가 변경 되었습니다."),
+    SUCCESS_REQUEST_FIND_MEMBER_ID(HttpStatus.OK.value(), "BMC011","회원 아이디 찾기 메일이 발송되었습니다.");
 
 
     private final int status;

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -2,10 +2,14 @@ package com.kernel360.member.controller;
 
 
 import com.kernel360.carinfo.entity.CarInfo;
+import com.kernel360.exception.BusinessException;
 import com.kernel360.member.code.MemberBusinessCode;
+import com.kernel360.member.code.MemberErrorCode;
 import com.kernel360.member.dto.CarInfoDto;
+import com.kernel360.member.dto.FindMemberIdFromEmailDto;
 import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.dto.WashInfoDto;
+import com.kernel360.member.service.FindService;
 import com.kernel360.member.service.MemberService;
 import com.kernel360.response.ApiResponse;
 import com.kernel360.washinfo.entity.WashInfo;
@@ -24,6 +28,8 @@ import static com.kernel360.member.code.MemberBusinessCode.SUCCESS_REQUEST_LOGIN
 public class MemberController {
 
     private final MemberService memberService;
+
+    private final FindService findService;
 
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<Object>> joinMember(@RequestBody MemberDto joinRequestDto) {
@@ -75,5 +81,17 @@ public class MemberController {
         return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_REQUEST_UPDATE_CAR_INFO_MEMBER);
     }
 
+    @PostMapping("/find/memberId")
+    public ResponseEntity<ApiResponse<Object>> sendMemberIdByEmail(@RequestBody FindMemberIdFromEmailDto dto) {
+        String memberId = memberService.findByEmail(dto.email()).getId();
 
+        if (memberId.isEmpty()) {
+            throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);
+        }
+
+        findService.sendMemberId(dto.email(), memberId);
+
+        return ApiResponse.toResponseEntity(
+                MemberBusinessCode.SUCCESS_REQUEST_FIND_MEMBER_ID); // 아이디는 이메일로 보내고, 외부 노출 X
+    }
 }

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -83,7 +83,7 @@ public class MemberController {
 
     @PostMapping("/find/memberId")
     public ResponseEntity<ApiResponse<Object>> sendMemberIdByEmail(@RequestBody FindMemberIdFromEmailDto dto) {
-        String memberId = memberService.findByEmail(dto.email()).getId();
+        String memberId = memberService.findByEmail(dto.email()).id();
 
         if (memberId.isEmpty()) {
             throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);

--- a/module-api/src/main/java/com/kernel360/member/dto/FindMemberIdFromEmailDto.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/FindMemberIdFromEmailDto.java
@@ -1,0 +1,7 @@
+package com.kernel360.member.dto;
+
+public record FindMemberIdFromEmailDto(String email) {
+    public static FindMemberIdFromEmailDto of(String email) {
+        return new FindMemberIdFromEmailDto(email);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/member/service/EmailSender.java
+++ b/module-api/src/main/java/com/kernel360/member/service/EmailSender.java
@@ -1,0 +1,5 @@
+package com.kernel360.member.service;
+
+public interface EmailSender {
+    void sendMemberId(String email, String memberId);
+}

--- a/module-api/src/main/java/com/kernel360/member/service/FindService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/FindService.java
@@ -1,0 +1,23 @@
+package com.kernel360.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FindService implements EmailSender {
+
+    private final JavaMailSender mailSender;
+
+    public void sendMemberId(String email, String memberId) {
+        new Thread(() -> mailSender.send(mimeMessage -> {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true);
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("Wash-Fit 아이디/패스워드 찾기");
+            String textContent = "가입하신 아이디는 " + "'" + memberId + "' 입니다.";
+            mimeMessageHelper.setText(textContent);
+        })).start();
+    }
+}

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -220,5 +220,8 @@ public class MemberService {
         carInfoRepository.save(carInfo);
     }
 
+    public Member findByEmail(String email) {
 
+        return memberRepository.findOneByEmail(email);
+    }
 }

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -220,8 +220,12 @@ public class MemberService {
         carInfoRepository.save(carInfo);
     }
 
-    public Member findByEmail(String email) {
+    public MemberDto findByEmail(String email) {
+        Member member = memberRepository.findOneByEmail(email);
+        if (member == null) {
+            throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);
+        }
 
-        return memberRepository.findOneByEmail(email);
+        return MemberDto.from(member);
     }
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -18,6 +18,20 @@ spring:
     autoconfigure:
       exclude: org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
+  mail:
+    host: smtp.gmail.com
+    username: ${SMTP_GOOGLE_EMAIL}
+    password: ${SMTP_PASSWORD}
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          connectiontimeout: 5000
+          starttls:
+            enable: true
+          timeout: 5000
+          writetimeout: 5000
 logging:
   file:
     path: ./logs/api/

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -20,6 +20,20 @@ spring:
     autoconfigure:
       exclude: org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
+  mail:
+    host: smtp.gmail.com
+    username: ENC(TEY+McqfBOprewh0EpDJIclJKk8o+bY/0CWpPynWeylc/HNeWGSI6Q==)
+    password: ENC(gAVZp58ZhI0MCJcvKFhB0lVNYPtMg35QIslSCJhu2pJB4ck+w1vscA==)
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          connectiontimeout: 5000
+          starttls:
+            enable: true
+          timeout: 5000
+          writetimeout: 5000
 jasypt:
   encryptor:
     algorithm: PBEWithMD5AndTripleDES

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -18,6 +18,21 @@ spring:
     autoconfigure:
       exclude: org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
+  mail:
+    host: smtp.gmail.com
+    username: ${SMTP_GOOGLE_EMAIL}
+    password: ${SMTP_PASSWORD}
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          connectiontimeout: 5000
+          starttls:
+            enable: true
+          timeout: 5000
+          writetimeout: 5000
+
 logging:
   file:
     path: ./logs/api/

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -1,18 +1,3 @@
 spring:
   profiles:
     active: local
-
-  mail:
-    host: smtp.gmail.com
-    username: ENC(TEY+McqfBOprewh0EpDJIclJKk8o+bY/0CWpPynWeylc/HNeWGSI6Q==)
-    password: ENC(gAVZp58ZhI0MCJcvKFhB0lVNYPtMg35QIslSCJhu2pJB4ck+w1vscA==)
-    port: 587
-    properties:
-      mail:
-        smtp:
-          auth: true
-          connectiontimeout: 5000
-          starttls:
-            enable: true
-          timeout: 5000
-          writetimeout: 5000

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -1,3 +1,18 @@
 spring:
   profiles:
     active: local
+
+  mail:
+    host: smtp.gmail.com
+    username: ENC(U0vAy8zw0HXxQko9Z3JGfxGEbKWkgIMUbg1fgq8qAxgMfWjYlpVAYw==)
+    password: ENC(4c7XVJmiLYFfahxZFSQLOase93b/OSC/GyS9FidIHanGx7PlAJRLLw==)
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          connectiontimeout: 5000
+          starttls:
+            enable: true
+          timeout: 5000
+          writetimeout: 5000

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
 
   mail:
     host: smtp.gmail.com
-    username: ENC(U0vAy8zw0HXxQko9Z3JGfxGEbKWkgIMUbg1fgq8qAxgMfWjYlpVAYw==)
-    password: ENC(4c7XVJmiLYFfahxZFSQLOase93b/OSC/GyS9FidIHanGx7PlAJRLLw==)
+    username: ENC(TEY+McqfBOprewh0EpDJIclJKk8o+bY/0CWpPynWeylc/HNeWGSI6Q==)
+    password: ENC(gAVZp58ZhI0MCJcvKFhB0lVNYPtMg35QIslSCJhu2pJB4ck+w1vscA==)
     port: 587
     properties:
       mail:

--- a/module-api/src/test/java/com/kernel360/common/ControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/common/ControllerTest.java
@@ -7,6 +7,7 @@ import com.kernel360.global.Interceptor.AcceptInterceptor;
 import com.kernel360.main.controller.MainContoller;
 import com.kernel360.main.service.MainService;
 import com.kernel360.member.controller.MemberController;
+import com.kernel360.member.service.FindService;
 import com.kernel360.member.service.MemberService;
 import com.kernel360.mypage.controller.MyPageController;
 import com.kernel360.product.controller.ProductController;
@@ -47,4 +48,7 @@ public abstract class ControllerTest {
 
     @MockBean
     protected MainService mainService;
+
+    @MockBean
+    protected FindService findService;
 }

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -1,17 +1,17 @@
 package com.kernel360.member.controller;
 
+import static org.mockito.BDDMockito.given;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kernel360.common.ControllerTest;
+import com.kernel360.member.dto.FindMemberIdFromEmailDto;
 import com.kernel360.member.dto.MemberDto;
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-
-import java.time.LocalDate;
-
-import static org.mockito.BDDMockito.given;
 
 
 class MemberControllerTest extends ControllerTest {
@@ -21,7 +21,7 @@ class MemberControllerTest extends ControllerTest {
     void 회원가입요청() throws Exception {
 
         /** given 목데이터 세팅 **/
-        MemberDto memberDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword", "man","30");
+        MemberDto memberDto = MemberDto.of("testID", "gunsight777@naver.com", "testPassword", "man", "30");
 
         ObjectMapper objectMapper = new ObjectMapper();
         String param = objectMapper.writeValueAsString(memberDto);
@@ -30,8 +30,8 @@ class MemberControllerTest extends ControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/member/join") //이 다음 restful
                                               .contentType(MediaType.APPLICATION_JSON)
                                               .content(param))
-                                              .andExpect(MockMvcResultMatchers.status().isCreated()) //기대 결과 상태값
-                                              .andReturn();
+               .andExpect(MockMvcResultMatchers.status().isCreated()) //기대 결과 상태값
+               .andReturn();
     }
 
     @Test
@@ -40,17 +40,17 @@ class MemberControllerTest extends ControllerTest {
 
         MemberDto memberDto = MemberDto.of("testID", "testPassword");
         MemberDto memberInfo = new MemberDto(1L,
-                                            "test01",
-                                            "kernel360@kernel360.com",
-                                            "",
-                                            null,
-                                            null,
-                                            LocalDate.now(),
-                                            "test01",
-                                            null,
-                                            null,
-                                            "dummyToken"
-            );
+                "test01",
+                "kernel360@kernel360.com",
+                "",
+                null,
+                null,
+                LocalDate.now(),
+                "test01",
+                null,
+                null,
+                "dummyToken"
+        );
         ObjectMapper objectMapper = new ObjectMapper();
         String param = objectMapper.writeValueAsString(memberDto);
 
@@ -60,8 +60,8 @@ class MemberControllerTest extends ControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/member/login")
                                               .contentType(MediaType.APPLICATION_JSON)
                                               .content(param))
-                                              .andExpect(MockMvcResultMatchers.status().isOk())
-                                              .andReturn();
+               .andExpect(MockMvcResultMatchers.status().isOk())
+               .andReturn();
 
     }
 
@@ -77,8 +77,8 @@ class MemberControllerTest extends ControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.get("/member/duplicatedCheckId/{id}", id)
                                               .contentType(MediaType.APPLICATION_JSON)
                                               .content(message))
-                                              .andExpect(MockMvcResultMatchers.status().isOk())
-                                              .andReturn();
+               .andExpect(MockMvcResultMatchers.status().isOk())
+               .andReturn();
     }
 
     @Test
@@ -93,9 +93,27 @@ class MemberControllerTest extends ControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.get("/member/duplicatedCheckEmail/{email}", email)
                                               .contentType(MediaType.APPLICATION_JSON)
                                               .content(message))
-                                              .andExpect(MockMvcResultMatchers.status().isOk())
-                                              .andReturn();
+               .andExpect(MockMvcResultMatchers.status().isOk())
+               .andReturn();
     }
 
 
+    @Test
+    @DisplayName("이메일을 입력 받아 아이디 찾기 이메일 발송")
+    void 아이디_찾기_이메일_발송_검사() throws Exception {
+        /** given 목데이터 세팅 **/
+        FindMemberIdFromEmailDto dto = FindMemberIdFromEmailDto.of("kernel360@gmail.com");
+        MemberDto memberDto = MemberDto.of("testMemberId", "testPassword001");
+
+        given(memberService.findByEmail(dto.email())).willReturn(memberDto);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String dtoAsString = objectMapper.writeValueAsString(dto);
+
+        /** then **/
+        mockMvc.perform(MockMvcRequestBuilders.post("/member/find/memberId")
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(dtoAsString))
+               .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+    }
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`아이디 찾기 기능 구현`

<br>

## 🔨 Modified
> Google SMTP 를 통해 분실한 아이디를 가입시 입력한 이메일로 발송합니다.
  - _local 환경에서는 jasypt, 나머지 환경에서는 github secrets 로 google SMTP 계정 정보를 관리합니다_

> 다음 이미지와 같이 이메일이 발송되는 것을 확인할 수 있습니다.
<img width="972" alt="image" src="https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/516d259e-8ab2-4e4b-898a-9c4402df8ee2">


<br>

## 🌟 More
- _비밀번호 찾기 기능 구현_

<br>

---


### 📋 커밋 전 체크리스트
- [x] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #154
