### PR TITLE
refactor :: 인증 관련 코드 리팩터링

### DIFF
--- a/module-api/src/docs/asciidoc/auth-api.adoc
+++ b/module-api/src/docs/asciidoc/auth-api.adoc
@@ -1,0 +1,14 @@
+== Auth API
+
+// [[]] 안에는 a 태그 이름 들어갑니다 (http://localhost:8080/docs/index#공통코드-조회)
+[[Auth-JWT재발급]]
+=== <JWT재발급요청>
+
+===== HTTP Request
+include::{snippets}/auth/reissuanceJWT/http-request.adoc[]
+
+==== Response
+include::{snippets}/auth/reissuanceJWT/response-fields.adoc[]
+
+===== HTTP Response 예시
+include::{snippets}/auth/reissuanceJWT/http-response.adoc[]

--- a/module-api/src/main/java/com/kernel360/auth/code/AuthBusinessCode.java
+++ b/module-api/src/main/java/com/kernel360/auth/code/AuthBusinessCode.java
@@ -1,0 +1,30 @@
+package com.kernel360.auth.code;
+
+import com.kernel360.code.BusinessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthBusinessCode implements BusinessCode {
+
+    SUCCESS_REQUEST_REGENERATED_JWT(HttpStatus.CREATED.value(), "BAC001", "JWT 토큰 재발급 성공");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/module-api/src/main/java/com/kernel360/auth/code/AuthErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/auth/code/AuthErrorCode.java
@@ -1,0 +1,30 @@
+package com.kernel360.auth.code;
+
+import com.kernel360.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    FAILED_GENERATED_JWT(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EAC001", "재발급충족미달");
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/module-api/src/main/java/com/kernel360/auth/controller/AuthController.java
+++ b/module-api/src/main/java/com/kernel360/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.kernel360.auth.controller;
+
+import com.kernel360.auth.dto.AuthDto;
+import com.kernel360.auth.service.AuthService;
+import com.kernel360.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.kernel360.auth.code.AuthBusinessCode.SUCCESS_REQUEST_REGENERATED_JWT;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/reissuanceJWT")
+    public ResponseEntity<ApiResponse<AuthDto>> reissuanceJWT(HttpServletRequest request){
+
+        return ApiResponse.toResponseEntity(SUCCESS_REQUEST_REGENERATED_JWT, AuthDto.of(authService.generateTokenAndSaveAuth(request.getHeader("Authorization"))));
+    }
+}

--- a/module-api/src/main/java/com/kernel360/auth/dto/AuthDto.java
+++ b/module-api/src/main/java/com/kernel360/auth/dto/AuthDto.java
@@ -1,0 +1,13 @@
+package com.kernel360.auth.dto;
+
+public record AuthDto(
+        String jwtToken
+) {
+    public static AuthDto of(
+            String jwtToken
+    ){
+        return new AuthDto(
+                jwtToken
+        );
+    }
+}

--- a/module-api/src/main/java/com/kernel360/auth/service/AuthService.java
+++ b/module-api/src/main/java/com/kernel360/auth/service/AuthService.java
@@ -18,15 +18,23 @@ public class AuthService {
 
     private final JWT jwt;
     private final AuthRepository authRepository;
-    public Auth findOneByMemberNo(Long memberNo) {  return authRepository.findOneByMemberNo(memberNo);  }
-    public Auth findOneAuthByJwt(String encryptToken) { return authRepository.findOneByJwtToken(encryptToken);  }
+    public Auth findOneByMemberNo(Long memberNo) {
+
+        return authRepository.findOneByMemberNo(memberNo);
+    }
+    public Auth findOneByJwt(String encryptToken) {
+
+        return authRepository.findOneByJwtToken(encryptToken);
+    }
+
     public boolean validRequestToken(String requestToken) {
         boolean result = jwt.validateToken(requestToken);
 
-        if(Objects.isNull(findOneAuthByJwt(ConvertSHA256.convertToSHA256(requestToken)))) { result = false; }
+        if(Objects.isNull(findOneByJwt(ConvertSHA256.convertToSHA256(requestToken)))) { result = false; }
 
         return result;
     }
+
     public String generateTokenAndSaveAuth(String requestToken) {
         String newToken = jwt.generateToken(JWT.ownerId(requestToken));
         Auth storedAuth = authRepository.findOneByJwtToken(ConvertSHA256.convertToSHA256(requestToken));
@@ -37,6 +45,7 @@ public class AuthService {
 
         return newToken;
     }
+
     // TODO refactor :: auth의 pk로 인해 조회 후 update - insert 를 결정하게 되어 줄일 필요가 있음. memberNo만으로 키를 잡는다면, flyway 또 수정해야함... 혹은 인증은 memorydb를 쓰는 방법 고려
     public void saveAuthByMember(Long memberNo, String encryptToken) {
         Auth authJwt = findOneByMemberNo(memberNo);
@@ -48,7 +57,12 @@ public class AuthService {
 
         authRepository.save(authJwt);
     }
-    public Auth createAuthJwt(Long memberNo, String encryptToken) { return Auth.of(null, memberNo, encryptToken, null); }
+
+    public Auth createAuthJwt(Long memberNo, String encryptToken) {
+
+        return Auth.of(null, memberNo, encryptToken, null);
+    }
+
     public Auth modifyAuthJwt(Auth modifyAuth, String encryptToken) {
         modifyAuth.updateJwt(encryptToken);
 

--- a/module-api/src/main/java/com/kernel360/auth/service/AuthService.java
+++ b/module-api/src/main/java/com/kernel360/auth/service/AuthService.java
@@ -1,0 +1,58 @@
+package com.kernel360.auth.service;
+
+import com.kernel360.auth.entity.Auth;
+import com.kernel360.auth.repository.AuthRepository;
+import com.kernel360.utils.ConvertSHA256;
+import com.kernel360.utils.JWT;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JWT jwt;
+    private final AuthRepository authRepository;
+    public Auth findOneByMemberNo(Long memberNo) {  return authRepository.findOneByMemberNo(memberNo);  }
+    public Auth findOneAuthByJwt(String encryptToken) { return authRepository.findOneByJwtToken(encryptToken);  }
+    public boolean validRequestToken(String requestToken) {
+        boolean result = jwt.validateToken(requestToken);
+
+        if(Objects.isNull(findOneAuthByJwt(ConvertSHA256.convertToSHA256(requestToken)))) { result = false; }
+
+        return result;
+    }
+    public String generateTokenAndSaveAuth(String requestToken) {
+        String newToken = jwt.generateToken(JWT.ownerId(requestToken));
+        Auth storedAuth = authRepository.findOneByJwtToken(ConvertSHA256.convertToSHA256(requestToken));
+
+        modifyAuthJwt(storedAuth, ConvertSHA256.convertToSHA256(newToken));
+
+        authRepository.save(storedAuth);
+
+        return newToken;
+    }
+    // TODO refactor :: auth의 pk로 인해 조회 후 update - insert 를 결정하게 되어 줄일 필요가 있음. memberNo만으로 키를 잡는다면, flyway 또 수정해야함... 혹은 인증은 memorydb를 쓰는 방법 고려
+    public void saveAuthByMember(Long memberNo, String encryptToken) {
+        Auth authJwt = findOneByMemberNo(memberNo);
+
+        //결과 없으면 entity로 신규 생성
+        authJwt = Optional.ofNullable(authJwt)
+                          .map(modifyAuth -> modifyAuthJwt(modifyAuth, encryptToken))
+                          .orElseGet(() -> createAuthJwt(memberNo, encryptToken));
+
+        authRepository.save(authJwt);
+    }
+    public Auth createAuthJwt(Long memberNo, String encryptToken) { return Auth.of(null, memberNo, encryptToken, null); }
+    public Auth modifyAuthJwt(Auth modifyAuth, String encryptToken) {
+        modifyAuth.updateJwt(encryptToken);
+
+        return modifyAuth;
+    }
+
+}

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
@@ -23,6 +23,8 @@ public class AcceptInterceptor implements HandlerInterceptor {
 
         if (!authService.validRequestToken(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN); }
 
+        //IP수집 후 테이블에 저장
+
         return result;
     }
 

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
@@ -1,11 +1,8 @@
 package com.kernel360.global.Interceptor;
 
-import com.kernel360.auth.entity.Auth;
+import com.kernel360.auth.service.AuthService;
 import com.kernel360.exception.BusinessException;
 import com.kernel360.global.code.AcceptInterceptorErrorCode;
-import com.kernel360.member.service.MemberService;
-import com.kernel360.utils.ConvertSHA256;
-import com.kernel360.utils.JWT;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,61 +13,17 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class AcceptInterceptor implements HandlerInterceptor {
 
-    private final JWT jwt;
-    private final MemberService memberService;
-    private static final int CLOSING_PERIOD = 2;
-
+    private final AuthService authService;
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         boolean result = true;
         String requestToken = request.getHeader("Authorization");
 
-        if (requestToken == null || requestToken.isEmpty()) { throw new BusinessException(AcceptInterceptorErrorCode.DOSE_NOT_EXIST_REQUEST_TOKEN); }
+        if (requestToken.length() == 0) { throw new BusinessException(AcceptInterceptorErrorCode.DOSE_NOT_EXIST_REQUEST_TOKEN); }
 
-        if (!validRequestToken(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN); }
-
-        long validRequestPeriod = validRequestPeriod(requestToken);
-
-        if ( (validRequestPeriod <= CLOSING_PERIOD) ) {
-            String encryptToken = ConvertSHA256.convertToSHA256(requestToken);
-            Auth storedAuthInfo = getOneAuthByJwt(encryptToken);
-            String newToken = reGeneratedToken(requestToken, storedAuthInfo);
-            response.setHeader("Authorization", newToken);
-        }
+        if (!authService.validRequestToken(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN); }
 
         return result;
-    }
-    private Auth getOneAuthByJwt(String encryptToken) {
-
-        Auth result = memberService.findOneAuthByJwt(encryptToken);
-
-        if(result == null) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN_HASH); }
-        if(!encryptToken.equals(result.getJwtToken())) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN_HASH); }
-
-        return result;
-    }
-
-    /**
-     * 토큰 자체의 유효성 검사 (서버 시크릿 키)
-     **/
-    private boolean validRequestToken(String requestToken) { return jwt.validateToken(requestToken); }
-
-    /**
-     * 토큰의 유효시간이 현재시간과 비교하여 2분 이하인지
-     **/
-    private long validRequestPeriod(String requestToken) { return jwt.checkedTime(requestToken); }
-
-    /**
-     * 신규토큰 발급 후 저장
-     **/
-    private String reGeneratedToken(String requestToken, Auth storedAuthInfo) {
-        String newToken = jwt.generateToken(jwt.ownerId(requestToken));
-        String newEncryptToken = ConvertSHA256.convertToSHA256(newToken);
-
-        storedAuthInfo = memberService.modifyAuthJwt(storedAuthInfo, newEncryptToken);
-        memberService.reissuanceJwt(storedAuthInfo);
-
-        return newToken;
     }
 
 }

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
@@ -13,7 +13,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(acceptInterceptor)
-                .addPathPatterns("/member/testJwt");
+                .addPathPatterns("/auth/validToken");
 //                .addPathPatterns("/mypage/**");
                 //.excludePathPatterns("/public/**"); // 제외할 URL 패턴
     }

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -51,13 +51,11 @@ public class MemberController {
 
     @GetMapping("/duplicatedCheckId/{id}")
     public boolean duplicatedCheckId (@PathVariable String id){
-
         return memberService.idDuplicationCheck(id);
     }
 
     @GetMapping("/duplicatedCheckEmail/{email}")
     public boolean duplicatedCheckEmail (@PathVariable String email){
-
         return memberService.emailDuplicationCheck(email);
     }
 

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -61,12 +61,6 @@ public class MemberController {
         return memberService.emailDuplicationCheck(email);
     }
 
-    @PostMapping("/testJwt")
-    public String testJwt (){
-        return "checked";
-    }
-
-
     @PostMapping("/wash")
     public ResponseEntity<ApiResponse<WashInfo>> saveWashInfo(@RequestBody WashInfoDto washInfo, @RequestHeader("Authorization") String authToken){
         memberService.saveWashInfo(washInfo, authToken);

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -43,10 +43,11 @@ public class MemberService {
     @Transactional
     public void joinMember(MemberDto requestDto) {
         Member entity = getNewJoinMemberEntity(requestDto);
-        if (entity == null) { throw new BusinessException(MemberErrorCode.FAILED_GENERATE_JOIN_MEMBER_INFO); }
+        if (entity == null) {   throw new BusinessException(MemberErrorCode.FAILED_GENERATE_JOIN_MEMBER_INFO);  }
 
         memberRepository.save(entity);
     }
+
     protected Member getNewJoinMemberEntity(MemberDto requestDto) {
         String encodePassword = ConvertSHA256.convertToSHA256(requestDto.password());
         int genderOrdinal;
@@ -55,17 +56,20 @@ public class MemberService {
         try {
             genderOrdinal = Gender.valueOf(requestDto.gender()).ordinal();
             ageOrdinal = Age.valueOf(requestDto.age()).ordinal();
-        } catch (Exception e) { throw new BusinessException(MemberErrorCode.FAILED_NOT_MAPPING_ENUM_VALUEOF); }
+        } catch (Exception e) {
+            throw new BusinessException(MemberErrorCode.FAILED_NOT_MAPPING_ENUM_VALUEOF);
+        }
 
         return Member.createJoinMember(requestDto.id(), requestDto.email(), encodePassword, genderOrdinal, ageOrdinal);
     }
+
     @Transactional
     public MemberDto login(MemberDto loginDto) {
         Member loginEntity = newReqeustLoginEntity(loginDto);
-        if (Objects.isNull(loginEntity)) {  throw new BusinessException(MemberErrorCode.FAILED_GENERATE_LOGIN_REQUEST_INFO);    }
+        if (Objects.isNull(loginEntity)) { throw new BusinessException(MemberErrorCode.FAILED_GENERATE_LOGIN_REQUEST_INFO);    }
 
         Member memberEntity = memberRepository.findOneByIdAndPassword(loginEntity.getId(), loginEntity.getPassword());
-        if (Objects.isNull(memberEntity)) { throw new BusinessException(MemberErrorCode.FAILED_REQUEST_LOGIN); }
+        if (Objects.isNull(memberEntity)) { throw new BusinessException(MemberErrorCode.FAILED_REQUEST_LOGIN);  }
 
         String loginToken = jwt.generateToken(memberEntity.getId());
 
@@ -73,17 +77,20 @@ public class MemberService {
 
         return MemberDto.login(memberEntity, loginToken);
     }
+
     private Member newReqeustLoginEntity(MemberDto loginDto) {
         String encodePassword = ConvertSHA256.convertToSHA256(loginDto.password());
 
         return Member.loginMember(loginDto.id(), encodePassword);
     }
+
     @Transactional(readOnly = true)
     public boolean idDuplicationCheck(String id) {
         Member member = memberRepository.findOneById(id);
 
         return member != null;
     }
+
     @Transactional(readOnly = true)
     public boolean emailDuplicationCheck(String email) {
         Member member = memberRepository.findOneByEmail(email);
@@ -96,17 +103,20 @@ public class MemberService {
 
         return MemberDto.from(memberRepository.findOneById(id));
     }
+
     public CarInfo findCarInfoByToken(@RequestHeader("Authorization") String authToken) {
         MemberDto memberDto = findMemberByToken(authToken);
 
         return memberDto.toEntity().getCarInfo();
     }
+
     @Transactional
     public void deleteMember(String id) {
         Member member = memberRepository.findOneById(id);
 
         memberRepository.delete(member);
     }
+
     @Transactional
     public void deleteMemberByToken(String token) {
         final String id = JWT.ownerId(token);
@@ -115,6 +125,7 @@ public class MemberService {
         memberRepository.delete(member);
         log.info("{} 회원 탈퇴 처리 완료", id);
     }
+
     @Transactional
     public void changePassword(String password, String token) {
         String id = JWT.ownerId(token);
@@ -123,8 +134,10 @@ public class MemberService {
         member.updatePassword(password);
         log.info("{} 회원의 비밀번호가 변경되었습니다.", id);
     }
+
     @Transactional
     public void updateMember(MemberInfo memberInfo) {   memberRepository.save(memberInfo.toEntity());   }
+
     @Transactional(readOnly = true)
     public Map<String, Object> getCarInfo(String token) {
         String id = JWT.ownerId(token);
@@ -140,6 +153,7 @@ public class MemberService {
                 "parking_options", commonCodeService.getCodes("parking")
         );
     }
+
     @Transactional
     public void saveWashInfo(WashInfoDto washInfoDto, String token) {
         String id = JWT.ownerId(token);
@@ -150,6 +164,7 @@ public class MemberService {
 
         washInfoRepository.save(washInfo);
     }
+
     @Transactional
     public void saveCarInfo(CarInfoDto carInfoDto, String token) {
         String id = JWT.ownerId(token);
@@ -160,6 +175,7 @@ public class MemberService {
 
         carInfoRepository.save(carInfo);
     }
+
     public MemberDto findByEmail(String email) {
         Member member = memberRepository.findOneByEmail(email);
         if (member == null) {   throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);   }

--- a/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AuthControllerTest extends ControllerTest {
 
     @Test
-    void 토큰_갱신요청이_왔을때_갱신이_잘_되는지() throws Exception {
+    void 토큰_갱신요청이_왔을때_리스폰스로_상태코드201과_갱신토큰이_잘_보내지는지() throws Exception {
         String requestToken = "token";
         String resultToken = "reissuanceToken";
 

--- a/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
@@ -1,0 +1,47 @@
+package com.kernel360.auth.controller;
+
+import com.kernel360.common.ControllerTest;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@AutoConfigureWebMvc
+class AuthControllerTest extends ControllerTest {
+
+    @Test
+    void 토큰_갱신요청이_왔을때_갱신이_잘_되는지() throws Exception {
+        String requestToken = "token";
+        String resultToken = "reissuanceToken";
+
+        when(authService.generateTokenAndSaveAuth(requestToken)).thenReturn(resultToken);
+
+        mockMvc.perform(get("/auth/reissuanceJWT")
+                       .header("Authorization", requestToken))
+               .andExpect(status().isCreated())
+               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+               .andExpect(jsonPath("$.status").value(201))
+               .andExpect(jsonPath("$.code").value("BAC001"))
+               .andExpect(jsonPath("$.message").value("JWT 토큰 재발급 성공"))
+                .andDo(document("auth/reissuanceJWT",
+                        responseFields(
+                                fieldWithPath("status").description("상태 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("code").description("비즈니스 코드"),
+                                fieldWithPath("value.jwtToken").type(JsonFieldType.STRING).description("JWT토큰")
+                        )))
+                .andReturn();
+    }
+}

--- a/module-api/src/test/java/com/kernel360/common/ControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/common/ControllerTest.java
@@ -1,6 +1,8 @@
 package com.kernel360.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kernel360.auth.controller.AuthController;
+import com.kernel360.auth.service.AuthService;
 import com.kernel360.commoncode.controller.CommonCodeController;
 import com.kernel360.commoncode.service.CommonCodeService;
 import com.kernel360.global.Interceptor.AcceptInterceptor;
@@ -23,7 +25,8 @@ import org.springframework.test.web.servlet.MockMvc;
         MemberController.class,
         ProductController.class,
         MainContoller.class,
-        MyPageController.class
+        MyPageController.class,
+        AuthController.class
 })
 @AutoConfigureRestDocs
 public abstract class ControllerTest {
@@ -51,4 +54,7 @@ public abstract class ControllerTest {
 
     @MockBean
     protected FindService findService;
+
+    @MockBean
+    protected AuthService authService;
 }

--- a/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.kernel360.member.service;
 
 import com.kernel360.auth.entity.Auth;
 import com.kernel360.auth.repository.AuthRepository;
+import com.kernel360.auth.service.AuthService;
 import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.entity.Member;
 import com.kernel360.member.repository.MemberRepository;
@@ -34,6 +35,9 @@ class MemberServiceTest {
 
     @InjectMocks
     private MemberService memberService;
+
+    @InjectMocks
+    private AuthService authService;
 
     @Mock
     private ConvertSHA256 convertSHA256;
@@ -119,8 +123,8 @@ class MemberServiceTest {
         Auth authJwt = authRepository.findOneByMemberNo(memberEntity.getMemberNo());
 
         authJwt = Optional.ofNullable(authJwt)
-                          .map(modifyAuth -> memberService.modifyAuthJwt(modifyAuth, encryptToken))
-                          .orElseGet(() -> memberService.createAuthJwt(memberEntity.getMemberNo(), encryptToken));
+                          .map(modifyAuth -> authService.modifyAuthJwt(modifyAuth, encryptToken))
+                          .orElseGet(() -> authService.createAuthJwt(memberEntity.getMemberNo(), encryptToken));
 
         authRepository.save(authJwt);
 


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`
 - 인증관련 기능 별도 도메인 추출 진행하였습니다.
 - 인증 도메인 코드 리팩터링 진행하였습니다.
 - 문서화를 위한 인증 도메인 controller 테스트코드 작성 하였습니다.

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - _여기에 세부 변경사항을 설명해주세요_
  - AcceptInterceptor가 아래와 같이 한결 가벼워졌습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/8cfc20db-8dbe-4152-883e-9981bbb99ccd)

최윤진 맨토님께서 Objects.isNull 활용을 제안해주셨는데 인터셉터에서 헤더 토큰값의 경우 사용이 부적절하여 가장 적합하다고 판단 된 비교법을 사용하였습니다.  다른분들도 사용 하실경우 참고하여 적용 부탁드립니다.

System.err.println("토큰검증 >>>> " + Objects.isNull(requestToken) + "value >>>> " + "_" + requestToken.length() + "_" + requestToken.getBytes() + "_" + requestToken);
로 로그를 찍어 볼 시 아래와 같은 결과 발생

        /*
        * Objects.isNull -> false
        * String.length -> 0
        * String.getBytes -> 객체주소
        * requestToken -> 빈값
        *
        * */

![스크린샷 2024-02-20 154828](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/34d4868e-72a9-4621-a418-25fd2599121a)
그 외 코드에선 테스트 후 적합하여 적용하였습니다.

- Auth 패키지로 인증관련 기능을 새로운 도메인으로 변경하였습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/aa01a966-b5ee-4c5e-b803-5c2a6f2528fb)

- MemberService에선 더 이상 authRepository를 직접 호출하지 않습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/579efd62-91ac-4d07-b02c-9f605bc4a247)

- 프론트엔드에서 주기적으로 토큰 갱신요청을 보낼 것이기 때문에 갱신용 컨트롤러를 만들었습니다.
  갱신요청의 유효성은 인터셉터에서 기존과 동일하게 처리합니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/0c32d164-963b-453f-825e-3c52b638fa75)

- 컨트롤러 테스트 코드 작성 후 문서화 하였습니다.
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/7641bc01-3e02-4510-84a3-c8c622dd7a48)


<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
- 네이버 소셜로그인, 카카오 소셜로그인

<br>


---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #150 
