### PR TITLE
Feature : 비밀번호 재설정 기능 추가

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -113,6 +113,7 @@ jobs:
             mkdir -p deploy
             cd deploy
             echo "${{ secrets.DB_INIT_SQL }}" > init.sql
+            echo "${{ secrets.DEV_REDIS_CONF }}" > redis.conf
             echo "${{ secrets.DOCKER_COMPOSE }}" > docker-compose.yml
             docker-compose pull
             docker-compose down

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -91,6 +91,7 @@ jobs:
             # Docker Compose
             mkdir -p deploy
             cd deploy
+            echo "${{ secrets.PROD_REDIS_CONF }}" > redis.conf
             echo "${{ secrets.DOCKER_COMPOSE_AWS }}" > docker-compose.yml
             
             docker-compose pull

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'

--- a/module-api/src/docs/asciidoc/member-find-credential-api.adoc
+++ b/module-api/src/docs/asciidoc/member-find-credential-api.adoc
@@ -1,0 +1,60 @@
+== 아이디/비밀번호 찾기 API
+
+[[아이디-찾기]]
+=== 아이디 찾기 이메일 발송
+
+===== HTTP Request
+include::{snippets}/member/find-memberId/request-fields.adoc[]
+
+===== HTTP Request 예시
+include::{snippets}/member/find-memberId/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member/find-memberId/response-fields.adoc[]
+
+===== HTTP Response 예시
+
+include::{snippets}/member/find-memberId/http-response.adoc[]
+
+[[비밀번호-찾기]]
+=== 비밀번호 재설정 이메일 발송
+
+===== HTTP Request
+include::{snippets}/member/find-password/request-fields.adoc[]
+
+===== HTTP Request 예시
+include::{snippets}/member/find-password/http-request.adoc[]
+
+==== Response
+include::{snippets}/member/find-password/response-fields.adoc[]
+
+===== HTTP Response 예시
+include::{snippets}/member/find-password/http-response.adoc[]
+
+=== 비밀번호 재설정 페이지 요청
+===== HTTP Request
+include::{snippets}/member/get-reset-password/query-parameters.adoc[]
+
+===== HTTP Request 예시
+include::{snippets}/member/get-reset-password/http-request.adoc[]
+
+==== Response
+include::{snippets}/member/get-reset-password/response-fields.adoc[]
+
+===== HTTP Response 예시
+include::{snippets}/member/get-reset-password/http-response.adoc[]
+
+
+=== 비밀번호 재설정 요청
+===== HTTP Request
+include::{snippets}/member/post-reset-password/http-request.adoc[]
+
+===== HTTP Request 예시
+include::{snippets}/member/post-reset-password/http-request.adoc[]
+
+==== Response
+include::{snippets}/member/post-reset-password/response-fields.adoc[]
+
+===== HTTP Response 예시
+include::{snippets}/member/post-reset-password/http-response.adoc[]

--- a/module-api/src/main/java/com/kernel360/global/config/RedisConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package com.kernel360.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private String port;
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(Integer.parseInt(port));
+        redisStandaloneConfiguration.setPassword(password);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/module-api/src/main/java/com/kernel360/member/code/MemberBusinessCode.java
+++ b/module-api/src/main/java/com/kernel360/member/code/MemberBusinessCode.java
@@ -17,8 +17,10 @@ public enum MemberBusinessCode implements BusinessCode {
     SUCCESS_VALIDATE_PASSWORD_MEMBER(HttpStatus.OK.value(), "BMC008", "비밀번호가 확인 되었습니다."),
     SUCCESS_REQUEST_UPDATE_WASH_INFO_MEMBER(HttpStatus.OK.value(), "BMC009", "WashInfo 정보가 변경 되었습니다."),
     SUCCESS_REQUEST_UPDATE_CAR_INFO_MEMBER(HttpStatus.OK.value(), "BMC010", "CarInfo 정보가 변경 되었습니다."),
-    SUCCESS_REQUEST_FIND_MEMBER_ID(HttpStatus.OK.value(), "BMC011","회원 아이디 찾기 메일이 발송되었습니다.");
-
+    SUCCESS_REQUEST_FIND_MEMBER_ID(HttpStatus.OK.value(), "BMC011", "회원 아이디 찾기 메일이 발송되었습니다."),
+    SUCCESS_REQUEST_SEND_RESET_PASSWORD_EMAIL(HttpStatus.OK.value(), "BMC012", "회원 비밀번호 초기화 메일이 발송되었습니다."),
+    SUCCESS_REQUEST_RESET_PASSWORD_PAGE(HttpStatus.FOUND.value(), "BMC013", "비밀번호 초기화 토큰이 유효하므로 비밀번호 초기화 페이지로 접근합니다."),
+    SUCCESS_REQUEST_RESET_PASSWORD(HttpStatus.OK.value(), "BMC013", "비밀번호가 초기화되었습니다.");
 
     private final int status;
     private final String code;

--- a/module-api/src/main/java/com/kernel360/member/code/MemberErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/member/code/MemberErrorCode.java
@@ -4,8 +4,6 @@ import com.kernel360.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-import java.util.EnumSet;
-
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 
@@ -15,7 +13,8 @@ public enum MemberErrorCode implements ErrorCode {
     FAILED_GENERATE_JOIN_MEMBER_INFO(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC004", "회원가입에 필요한 정보 생성 실패"),
     FAILED_GENERATE_LOGIN_REQUEST_INFO(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC005", "정보 불일치로 인한 로그인 정보 생성 실패"),
     FAILED_REQUEST_LOGIN(HttpStatus.BAD_REQUEST.value(), "EMC006", "정보 불일치로 인한 로그인 실패"),
-    FAILED_FIND_MEMBER_INFO(HttpStatus.BAD_REQUEST.value(), "EMC007", "요청 회원정보가 존재하지 않습니다.");
+    FAILED_FIND_MEMBER_INFO(HttpStatus.BAD_REQUEST.value(), "EMC007", "요청 회원정보가 존재하지 않습니다."),
+    EXPIRED_PASSWORD_RESET_TOKEN(HttpStatus.NOT_FOUND.value(), "EMC008", "유효하지 않은 비밀번호 초기화 토큰입니다");
 
 
     private final int status;

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -6,13 +6,14 @@ import com.kernel360.exception.BusinessException;
 import com.kernel360.member.code.MemberBusinessCode;
 import com.kernel360.member.code.MemberErrorCode;
 import com.kernel360.member.dto.CarInfoDto;
-import com.kernel360.member.dto.FindMemberIdFromEmailDto;
+import com.kernel360.member.dto.MemberCredentialDto;
 import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.dto.WashInfoDto;
-import com.kernel360.member.service.FindService;
+import com.kernel360.member.service.FindCredentialService;
 import com.kernel360.member.service.MemberService;
 import com.kernel360.response.ApiResponse;
 import com.kernel360.washinfo.entity.WashInfo;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    private final FindService findService;
+    private final FindCredentialService findCredentialService;
 
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<Object>> joinMember(@RequestBody MemberDto joinRequestDto) {
@@ -50,19 +51,19 @@ public class MemberController {
     }
 
     @GetMapping("/duplicatedCheckId/{id}")
-    public boolean duplicatedCheckId (@PathVariable String id){
+    public boolean duplicatedCheckId(@PathVariable String id) {
 
         return memberService.idDuplicationCheck(id);
     }
 
     @GetMapping("/duplicatedCheckEmail/{email}")
-    public boolean duplicatedCheckEmail (@PathVariable String email){
+    public boolean duplicatedCheckEmail(@PathVariable String email) {
 
         return memberService.emailDuplicationCheck(email);
     }
 
     @PostMapping("/testJwt")
-    public String testJwt (){
+    public String testJwt() {
         return "checked";
     }
 
@@ -81,17 +82,43 @@ public class MemberController {
         return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_REQUEST_UPDATE_CAR_INFO_MEMBER);
     }
 
-    @PostMapping("/find/memberId")
-    public ResponseEntity<ApiResponse<Object>> sendMemberIdByEmail(@RequestBody FindMemberIdFromEmailDto dto) {
-        String memberId = memberService.findByEmail(dto.email()).id();
+    @PostMapping("/find-memberId")
+    public ResponseEntity<ApiResponse<Object>> sendMemberIdByEmail(@RequestBody MemberCredentialDto credentialDto) {
+        String memberId = memberService.findByEmail(credentialDto.email()).id();
 
-        if (memberId.isEmpty()) {
-            throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);
+        findCredentialService.sendMemberId(credentialDto.email(), memberId);
+
+        return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_REQUEST_FIND_MEMBER_ID);
+    }
+
+    @PostMapping("/find-password")
+    public ResponseEntity<ApiResponse<Object>> sendPasswordResetUriByEmail(@RequestBody MemberCredentialDto dto,
+                                                                           HttpServletRequest request) {
+        //--입력받은 아이디를 데이터베이스에 조회, 없으면 예외 발생--/
+        MemberDto memberDto = memberService.findByMemberId(dto.memberId());
+        //--유효성이 검증된 아이디에 대해서 만료시간이 있는 비밀번호 초기화 (호스트 + UUID) 링크 생성 --//
+        String resetUri = findCredentialService.generatePasswordResetUri(request, memberDto);
+        //-- 가입시 입력한 이메일로 비밀번호 초기화 이메일 발송 --//
+        findCredentialService.sendPasswordResetUri(resetUri, memberDto);
+
+        return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_REQUEST_SEND_RESET_PASSWORD_EMAIL);
+    }
+
+    @GetMapping("/reset-password")
+    public ResponseEntity<ApiResponse<Object>> getPasswordResetPage(@RequestParam String token) {
+        String memberId = findCredentialService.getData(token);
+        if (memberId == null) {
+            throw new BusinessException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
         }
 
-        findService.sendMemberId(dto.email(), memberId);
+        return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_REQUEST_RESET_PASSWORD_PAGE, token);
+    }
 
-        return ApiResponse.toResponseEntity(
-                MemberBusinessCode.SUCCESS_REQUEST_FIND_MEMBER_ID); // 아이디는 이메일로 보내고, 외부 노출 X
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse<Object>> resetPassword(@RequestBody MemberCredentialDto credentialDto) {
+        String authKey = findCredentialService.resetPassword(credentialDto);
+        findCredentialService.expireData(authKey);
+
+        return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_REQUEST_RESET_PASSWORD);
     }
 }

--- a/module-api/src/main/java/com/kernel360/member/dto/FindMemberIdFromEmailDto.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/FindMemberIdFromEmailDto.java
@@ -1,7 +1,0 @@
-package com.kernel360.member.dto;
-
-public record FindMemberIdFromEmailDto(String email) {
-    public static FindMemberIdFromEmailDto of(String email) {
-        return new FindMemberIdFromEmailDto(email);
-    }
-}

--- a/module-api/src/main/java/com/kernel360/member/dto/MemberCredentialDto.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/MemberCredentialDto.java
@@ -1,0 +1,11 @@
+package com.kernel360.member.dto;
+
+public record MemberCredentialDto(String authToken,
+                                  String email,
+                                  String memberId,
+                                  String password) {
+    public static MemberCredentialDto of(String authToken, String email, String memberId, String password) {
+
+        return new MemberCredentialDto(authToken, email, memberId, password);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/member/dto/MemberCredentialDto.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/MemberCredentialDto.java
@@ -1,9 +1,11 @@
 package com.kernel360.member.dto;
 
-public record MemberCredentialDto(String authToken,
-                                  String email,
-                                  String memberId,
-                                  String password) {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MemberCredentialDto(@JsonProperty("authToken") String authToken,
+                                  @JsonProperty("email") String email,
+                                  @JsonProperty("memberId") String memberId,
+                                  @JsonProperty("password") String password) {
     public static MemberCredentialDto of(String authToken, String email, String memberId, String password) {
 
         return new MemberCredentialDto(authToken, email, memberId, password);

--- a/module-api/src/main/java/com/kernel360/member/service/EmailSender.java
+++ b/module-api/src/main/java/com/kernel360/member/service/EmailSender.java
@@ -1,5 +1,5 @@
 package com.kernel360.member.service;
 
 public interface EmailSender {
-    void sendMemberId(String email, String memberId);
+    void sendMail(String to, String subject, String content);
 }

--- a/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
@@ -5,6 +5,7 @@ import com.kernel360.member.code.MemberErrorCode;
 import com.kernel360.member.dto.MemberCredentialDto;
 import com.kernel360.member.dto.MemberDto;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -114,7 +115,7 @@ public class FindCredentialService implements RedisUtils {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         String value = valueOperations.get(credentialDto.authToken());
 
-        if (value == null) {
+        if (Objects.isNull(value)) {
             throw new BusinessException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
         }
 
@@ -131,7 +132,7 @@ public class FindCredentialService implements RedisUtils {
     @Override
     public String getData(String key) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        if (valueOperations.get(key) == null) {
+        if (Objects.isNull(valueOperations.get(key))) {
             throw new BusinessException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
         }
 
@@ -154,7 +155,7 @@ public class FindCredentialService implements RedisUtils {
     @Override
     public void getAndExpireData(String key) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        if (valueOperations.get(key) == null) {
+        if (Objects.isNull(valueOperations.get(key))) {
             throw new BusinessException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
         }
 

--- a/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
@@ -4,10 +4,10 @@ import com.kernel360.exception.BusinessException;
 import com.kernel360.member.code.MemberErrorCode;
 import com.kernel360.member.dto.MemberCredentialDto;
 import com.kernel360.member.dto.MemberDto;
-import jakarta.servlet.http.HttpServletRequest;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
@@ -16,6 +16,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Service
 @RequiredArgsConstructor
 public class FindCredentialService implements RedisUtils {
+
+    @Value("${constants.password-reset-token.duration-minute}")
+    private int TOKEN_DURATION;
+
+    @Value("${constants.host-url}")
+    private String HOST_HTTP_URL;
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -54,56 +60,52 @@ public class FindCredentialService implements RedisUtils {
 
     public void sendPasswordResetUri(String resetUri, MemberDto dto) {
 
-        String resetHyperLink = "<a href=\"" + resetUri
-                + "\" style=\"display:inline-block;background:#fc1c49;border-radius:4px;font-weight:700;font-size:16px;line-height:1.5;"
-                + "text-align:center;color:#ffffff;text-decoration:none;padding:12px 16px;box-sizing:border-box;height:48px\""
-                + " target=\"_blank\">패스워드 재설정하기</a>";
-
-        String htmlContent =
-                "<div style=\"margin:0;padding:0;font-size:14px;line-height:1.5;background-color:#fff;color:#2e2e2e;font-weight:400\">\n"
-                        +
-                        "  <table style=\"margin:40px auto 20px;text-align:left;border-collapse:collapse;border:0;width:600px;padding:64px 16px;box-sizing:border-box;display:block\">\n"
-                        +
-                        "    <tbody>\n" +
-                        "      <tr>\n" +
-                        "        <td><h1>Wash-Fit 아이디/패스워드 찾기</h1></td>\n" +
-                        "      </tr>\n" +
-                        "      <tr>\n" +
-                        "        <td>\n" +
-                        "          <p style=\"padding-top:48px;font-weight:700;font-size:20px;line-height:1.5;color:#222\">\n"
-                        +
-                        "            Wash-Fit 계정의 비밀번호를 변경합니다.\n" +
-                        "          </p>\n" +
-                        "          <p style=\"font-size:16px;font-weight:400;line-height:1.5;padding-top:16px\">\n" +
-                        "            아래의 링크를 통해 패스워드를 재설정해주세요.\n" +
-                        "          </p>\n" +
-                        "          <div style=\"padding-top:48px\">\n" + resetHyperLink +
-                        "          </div>\n" +
-                        "        </td>\n" +
-                        "      </tr>\n" +
-                        "      <tr>\n" +
-                        "        <td style=\"padding-top:48px\" colspan(\"2\")>\n" +
-                        "          <p>기타 질문사항은 고객센터에 문의 주시길 바랍니다.</p>\n" +
-                        "        </td>\n" +
-                        "      </tr>\n" +
-                        "    </tbody>\n" +
-                        "  </table>\n" +
-                        "</div>";
+        String htmlContent = "<!DOCTYPE html>\n"
+                + "<html lang=\"ko\">\n"
+                + "<head>\n"
+                + "    <meta charset=\"UTF-8\">\n"
+                + "    <title>Password Recovery</title>\n"
+                + "</head>\n"
+                + "<body style=\"font-family: Arial, sans-serif;\">\n"
+                + "<div style=\"margin: 0 auto; max-width: 700px;\">\n"
+                + "    <div style=\"text-align: center;\">\n"
+                + "        <img src=\"/placeholder.svg\" alt=\"WashFit\" style=\"width: 100px; height: 100px; object-fit: cover;\">\n"
+                + "        <h1 style=\"font-size: 1.5em; font-weight: bold;\">WashFit 계정의 비밀번호를 변경합니다.</h1>\n"
+                + "        <p>아래의 링크를 통해 패스워드를 재설정하세요.</p>\n"
+                + "        <a href=" + resetUri + "\n"
+                + "           style=\"display: inline-block; padding: 6px 20px; text-decoration: none; border-radius: 5px; text-align: center; font-weight: bold; color: white; background-color: #0075FF;\">\n"
+                + "            패스워드 재설정하기\n"
+                + "        </a>\n"
+                + "    </div>\n"
+                + "    <br>\n"
+                + "    <div style=\"border-top: 1px solid lightgrey; padding: 20px; text-align:center;\">\n"
+                + "        <h2 style=\"font-weight:bold; font-size: 1.2em;\">고객센터 운영시간</h2>\n"
+                + "        <p>평일 10:00~19:00 (주말 및 공휴일 제외/ 점심시간 13:00~14:00)</p>\n"
+                + "        <a href=\"mailto:support@example.com\"\n"
+                + "           style=\"display: inline-block; padding: 6px 20px; text-decoration: none; text-align: center; font-weight: bold; color: black; background-color: lightgrey; width: 50%;\">"
+                + "고객센터 문의하기</a>\n"
+                + "    </div>\n"
+                + "    <div style=\"border-top: 1px solid lightgrey; padding: 20px; text-align:center;\">\n"
+                + "        <p style=\"font-weight:bold;\">FAST CAMPUS</p>\n"
+                + "        <p>(주)데이원캠퍼니</p>\n"
+                + "        <p>서울특별시 강남구 테헤란로 231, 센트럴프라자 WEST 6층, 7층</p>\n"
+                + "    </div>\n"
+                + "</div>\n"
+                + "</body>\n"
+                + "</html>";
 
         emailService.sendMail(dto.email(), "[No-Reply] Wash-Fit 아이디/비밀번호 찾기", htmlContent);
     }
 
-    public String generatePasswordResetUri(HttpServletRequest request, MemberDto memberDto) {
+    public String generatePasswordResetUri(MemberDto memberDto) {
         String resetToken = generateUUID();
 
-        String uriString = UriComponentsBuilder.newInstance()
-                                               .scheme("http")
-                                               .host(request.getHeader("host"))
+        String uriString = UriComponentsBuilder.fromHttpUrl(HOST_HTTP_URL)
                                                .path("/member/reset-password")
                                                .queryParam("token", resetToken)
                                                .build()
                                                .toUriString();
-        setExpiringData(resetToken, memberDto.id(), 5); // duration 값 상수로 변경관리 필요
+        setExpiringData(resetToken, memberDto.id(), TOKEN_DURATION); // duration 값 상수로 변경관리 필요
 
         return uriString;
     }
@@ -129,7 +131,11 @@ public class FindCredentialService implements RedisUtils {
     @Override
     public String getData(String key) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        return valueOperations.get(key); // TODO :: refactor
+        if (valueOperations.get(key) == null) {
+            throw new BusinessException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
+        }
+
+        return valueOperations.get(key);
     }
 
     @Override
@@ -146,8 +152,12 @@ public class FindCredentialService implements RedisUtils {
     }
 
     @Override
-    public void expireData(String key) {
+    public void getAndExpireData(String key) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        if (valueOperations.get(key) == null) {
+            throw new BusinessException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
+        }
+
         valueOperations.getAndDelete(key);
     }
 }

--- a/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
@@ -1,0 +1,153 @@
+package com.kernel360.member.service;
+
+import com.kernel360.exception.BusinessException;
+import com.kernel360.member.code.MemberErrorCode;
+import com.kernel360.member.dto.MemberCredentialDto;
+import com.kernel360.member.dto.MemberDto;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class FindCredentialService implements RedisUtils {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final MemberService memberService;
+
+    private final SendEmailService emailService;
+
+    public void sendMemberId(String email, String memberId) {
+        String textContent = "가입하신 아이디는 " + "'" + memberId + "' 입니다.";
+        String htmlContent =
+                "<div style=\"margin:0;padding:0;font-size:14px;line-height:1.5;background-color:#fff;color:#2e2e2e;font-weight:400\">\n"
+                        +
+                        "  <table style=\"margin:40px auto 20px;text-align:left;border-collapse:collapse;border:0;width:600px;padding:64px 16px;box-sizing:border-box;display:block\">\n"
+                        +
+                        "    <tbody>\n" +
+                        "      <tr>\n" +
+                        "        <td><h1>Wash-Fit 아이디/패스워드 찾기</h1></td>\n" +
+                        "      </tr>\n" +
+                        "      <tr>\n" +
+                        "        <td>\n" +
+                        "          <div style=\"padding-top:48px\">\n" + textContent +
+                        "          </div>\n" +
+                        "        </td>\n" +
+                        "      </tr>\n" +
+                        "      <tr>\n" +
+                        "        <td style=\"padding-top:48px\" colspan(\"2\")>\n" +
+                        "          <p>기타 질문사항은 고객센터에 문의 주시길 바랍니다.</p>\n" +
+                        "        </td>\n" +
+                        "      </tr>\n" +
+                        "    </tbody>\n" +
+                        "  </table>\n" +
+                        "</div>";
+
+        emailService.sendMail(email, "[No-Reply] Wash-Fit 아이디/비밀번호 찾기", htmlContent);
+    }
+
+    public void sendPasswordResetUri(String resetUri, MemberDto dto) {
+
+        String resetHyperLink = "<a href=\"" + resetUri
+                + "\" style=\"display:inline-block;background:#fc1c49;border-radius:4px;font-weight:700;font-size:16px;line-height:1.5;"
+                + "text-align:center;color:#ffffff;text-decoration:none;padding:12px 16px;box-sizing:border-box;height:48px\""
+                + " target=\"_blank\">패스워드 재설정하기</a>";
+
+        String htmlContent =
+                "<div style=\"margin:0;padding:0;font-size:14px;line-height:1.5;background-color:#fff;color:#2e2e2e;font-weight:400\">\n"
+                        +
+                        "  <table style=\"margin:40px auto 20px;text-align:left;border-collapse:collapse;border:0;width:600px;padding:64px 16px;box-sizing:border-box;display:block\">\n"
+                        +
+                        "    <tbody>\n" +
+                        "      <tr>\n" +
+                        "        <td><h1>Wash-Fit 아이디/패스워드 찾기</h1></td>\n" +
+                        "      </tr>\n" +
+                        "      <tr>\n" +
+                        "        <td>\n" +
+                        "          <p style=\"padding-top:48px;font-weight:700;font-size:20px;line-height:1.5;color:#222\">\n"
+                        +
+                        "            Wash-Fit 계정의 비밀번호를 변경합니다.\n" +
+                        "          </p>\n" +
+                        "          <p style=\"font-size:16px;font-weight:400;line-height:1.5;padding-top:16px\">\n" +
+                        "            아래의 링크를 통해 패스워드를 재설정해주세요.\n" +
+                        "          </p>\n" +
+                        "          <div style=\"padding-top:48px\">\n" + resetHyperLink +
+                        "          </div>\n" +
+                        "        </td>\n" +
+                        "      </tr>\n" +
+                        "      <tr>\n" +
+                        "        <td style=\"padding-top:48px\" colspan(\"2\")>\n" +
+                        "          <p>기타 질문사항은 고객센터에 문의 주시길 바랍니다.</p>\n" +
+                        "        </td>\n" +
+                        "      </tr>\n" +
+                        "    </tbody>\n" +
+                        "  </table>\n" +
+                        "</div>";
+
+        emailService.sendMail(dto.email(), "[No-Reply] Wash-Fit 아이디/비밀번호 찾기", htmlContent);
+    }
+
+    public String generatePasswordResetUri(HttpServletRequest request, MemberDto memberDto) {
+        String resetToken = generateUUID();
+
+        String uriString = UriComponentsBuilder.newInstance()
+                                               .scheme("http")
+                                               .host(request.getHeader("host"))
+                                               .path("/member/reset-password")
+                                               .queryParam("token", resetToken)
+                                               .build()
+                                               .toUriString();
+        setExpiringData(resetToken, memberDto.id(), 5); // duration 값 상수로 변경관리 필요
+
+        return uriString;
+    }
+
+    public String resetPassword(MemberCredentialDto credentialDto) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String value = valueOperations.get(credentialDto.authToken());
+
+        if (value == null) {
+            throw new BusinessException(MemberErrorCode.EXPIRED_PASSWORD_RESET_TOKEN);
+        }
+
+        memberService.resetPasswordByMemberId(value, credentialDto.password());
+
+        return credentialDto.authToken();
+    }
+
+    private String generateUUID() {
+
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key); // TODO :: refactor
+    }
+
+    @Override
+    public void setData(String key, String value) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    @Override
+    public void setExpiringData(String key, String value, int duration) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofMinutes(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    @Override
+    public void expireData(String key) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.getAndDelete(key);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/member/service/RedisUtils.java
+++ b/module-api/src/main/java/com/kernel360/member/service/RedisUtils.java
@@ -1,0 +1,12 @@
+package com.kernel360.member.service;
+
+public interface RedisUtils {
+
+    Object getData(String key);
+
+    void setData(String key, String value);
+
+    void setExpiringData(String key, String value, int duration);
+
+    void expireData(String key);
+}

--- a/module-api/src/main/java/com/kernel360/member/service/RedisUtils.java
+++ b/module-api/src/main/java/com/kernel360/member/service/RedisUtils.java
@@ -8,5 +8,5 @@ public interface RedisUtils {
 
     void setExpiringData(String key, String value, int duration);
 
-    void expireData(String key);
+    void getAndExpireData(String key);
 }

--- a/module-api/src/main/java/com/kernel360/member/service/SendEmailService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/SendEmailService.java
@@ -7,17 +7,18 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class FindService implements EmailSender {
+public class SendEmailService implements EmailSender {
 
     private final JavaMailSender mailSender;
 
-    public void sendMemberId(String email, String memberId) {
+    @Override
+    public void sendMail(String to, String subject, String content) {
+
         new Thread(() -> mailSender.send(mimeMessage -> {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true);
-            mimeMessageHelper.setTo(email);
-            mimeMessageHelper.setSubject("Wash-Fit 아이디/패스워드 찾기");
-            String textContent = "가입하신 아이디는 " + "'" + memberId + "' 입니다.";
-            mimeMessageHelper.setText(textContent);
+            mimeMessageHelper.setTo(to);
+            mimeMessageHelper.setSubject(subject);
+            mimeMessageHelper.setText(content, true);
         })).start();
     }
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -40,8 +40,8 @@ spring:
         pool:
           max-active: 20
           max-idle: 20
-      host: ${REDIS_DEV_HOST} # 아직 안 만듬
-      password: ${REDIS_DEV_PASSWORD} # 아직 안 만듬
+      host: ${REDIS_DEV_HOST}
+      password: ${REDIS_DEV_PASSWORD}
 
 logging:
   file:

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -32,6 +32,17 @@ spring:
             enable: true
           timeout: 5000
           writetimeout: 5000
+
+  data:
+    redis:
+      port: 6379
+      lettuce:
+        pool:
+          max-active: 20
+          max-idle: 20
+      host: ${REDIS_DEV_HOST} # 아직 안 만듬
+      password: ${REDIS_DEV_PASSWORD} # 아직 안 만듬
+
 logging:
   file:
     path: ./logs/api/
@@ -50,3 +61,8 @@ management:
   endpoint:
     health:
       show-details: always
+
+constants:
+  host-url: ${DEV_HOST_URL}
+  password-reset-token:
+    duration-minute: 5

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -34,6 +34,16 @@ spring:
             enable: true
           timeout: 5000
           writetimeout: 5000
+  data:
+    redis:
+      port: 6379
+      lettuce:
+        pool:
+          max-active: 20
+          max-idle: 20
+      host: 127.0.0.1
+      password:
+
 jasypt:
   encryptor:
     algorithm: PBEWithMD5AndTripleDES

--- a/module-api/src/main/resources/application-local.yml
+++ b/module-api/src/main/resources/application-local.yml
@@ -34,6 +34,7 @@ spring:
             enable: true
           timeout: 5000
           writetimeout: 5000
+
   data:
     redis:
       port: 6379
@@ -42,7 +43,7 @@ spring:
           max-active: 20
           max-idle: 20
       host: 127.0.0.1
-      password:
+      password: wash1234
 
 jasypt:
   encryptor:
@@ -66,3 +67,9 @@ management:
   endpoint:
     health:
       show-details: always
+
+constants:
+  host-url: "http://localhost:8080"
+  password-reset-token:
+    duration-minute: 5
+

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -40,8 +40,8 @@ spring:
         pool:
           max-active: 20
           max-idle: 20
-      host: ${REDIS_PROD_HOST} # 아직 안 만듬
-      password: ${REDIS_PROD_PASSWORD} # 아직 안 만듬
+      host: ${REDIS_PROD_HOST}
+      password: ${REDIS_PROD_PASSWORD}
 
 logging:
   file:

--- a/module-api/src/main/resources/application-prod.yml
+++ b/module-api/src/main/resources/application-prod.yml
@@ -33,6 +33,16 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
+  data:
+    redis:
+      port: 6379
+      lettuce:
+        pool:
+          max-active: 20
+          max-idle: 20
+      host: ${REDIS_PROD_HOST} # 아직 안 만듬
+      password: ${REDIS_PROD_PASSWORD} # 아직 안 만듬
+
 logging:
   file:
     path: ./logs/api/
@@ -51,3 +61,8 @@ management:
   endpoint:
     health:
       show-details: always
+
+constants:
+  host-url: ${PROD_HOST_URL}
+  password-reset-token:
+    duration-minute: 5

--- a/module-api/src/test/java/com/kernel360/common/ControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/common/ControllerTest.java
@@ -7,7 +7,7 @@ import com.kernel360.global.Interceptor.AcceptInterceptor;
 import com.kernel360.main.controller.MainContoller;
 import com.kernel360.main.service.MainService;
 import com.kernel360.member.controller.MemberController;
-import com.kernel360.member.service.FindService;
+import com.kernel360.member.service.FindCredentialService;
 import com.kernel360.member.service.MemberService;
 import com.kernel360.mypage.controller.MyPageController;
 import com.kernel360.product.controller.ProductController;
@@ -50,5 +50,5 @@ public abstract class ControllerTest {
     protected MainService mainService;
 
     @MockBean
-    protected FindService findService;
+    protected FindCredentialService findCredentialService;
 }

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -1,6 +1,14 @@
 package com.kernel360.member.controller;
 
+import static com.kernel360.common.utils.RestDocumentUtils.getDocumentRequest;
+import static com.kernel360.common.utils.RestDocumentUtils.getDocumentResponse;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kernel360.common.ControllerTest;
@@ -10,6 +18,8 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -111,9 +121,110 @@ class MemberControllerTest extends ControllerTest {
         String dtoAsString = objectMapper.writeValueAsString(dto);
 
         /** then **/
-        mockMvc.perform(MockMvcRequestBuilders.post("/member/find/memberId")
+        mockMvc.perform(MockMvcRequestBuilders.post("/member/find-memberId")
                                               .contentType(MediaType.APPLICATION_JSON)
                                               .content(dtoAsString))
-               .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+               .andExpect(MockMvcResultMatchers.status().isOk()).andDo(document(
+                       "member/find-memberId", getDocumentRequest(), getDocumentResponse(),
+                       requestFields(
+                               fieldWithPath("email").type(JsonFieldType.STRING).description("회원가입시 입력한 이메일"),
+                               fieldWithPath("authToken").type(JsonFieldType.NULL).description("비밀번호 재설정 UUID 토큰(사용하지 않음)"),
+                               fieldWithPath("memberId").type(JsonFieldType.NULL).description("회원 아이디(사용하지 않음)"),
+                               fieldWithPath("password").type(JsonFieldType.NULL).description("변경할 비밀번호(사용하지 않음)")
+                       ),
+                       responseFields(
+                               fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                               fieldWithPath("code").type(JsonFieldType.STRING).description("비즈니스 코드"),
+                               fieldWithPath("message").type(JsonFieldType.STRING).description("상세 메시지"),
+                               fieldWithPath("value").type(JsonFieldType.NULL).description("JSON BODY 데이터")
+                       )));
+    }
+
+    @Test
+    @DisplayName("회원 아이디를 입력받아 비밀번호 재설정 이메일 발송에 성공한다")
+    void 회원_아이디로_비밀번호_재설정_이메일_발송_검사() throws Exception {
+        // given
+        MemberCredentialDto credentialDto = MemberCredentialDto.of(null, null, "kernel360", null);
+        MemberDto memberDto = MemberDto.of("testMemberId", "testPassword001");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        given(memberService.findByMemberId(credentialDto.memberId())).willReturn(memberDto);
+        given(findCredentialService.generatePasswordResetUri(request, memberDto)).willReturn("테스트 URI");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String dtoAsString = objectMapper.writeValueAsString(credentialDto);
+
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.post("/member/find-password")
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(dtoAsString))
+               .andExpect(MockMvcResultMatchers.status().isOk()).andDo(document(
+                       "member/find-password", getDocumentRequest(), getDocumentResponse(),
+                       requestFields(
+                               fieldWithPath("email").type(JsonFieldType.NULL).description("회원가입시 입력한 이메일(사용하지 않음)"),
+                               fieldWithPath("authToken").type(JsonFieldType.NULL).description("비밀번호 재설정 UUID 토큰(사용하지 않음)"),
+                               fieldWithPath("memberId").type(JsonFieldType.STRING).description("회원 아이디"),
+                               fieldWithPath("password").type(JsonFieldType.NULL).description("변경할 비밀번호(사용하지 않음)")
+                       ),
+                       responseFields(
+                               fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                               fieldWithPath("code").type(JsonFieldType.STRING).description("비즈니스 코드"),
+                               fieldWithPath("message").type(JsonFieldType.STRING).description("상세 메시지"),
+                               fieldWithPath("value").type(JsonFieldType.NULL).description("JSON BODY 데이터")
+                       )));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 토큰을 확인하여 비밀번호 재설정 페이지 반환에 성공")
+    void 비밀번호_재설정_토큰을_확인하고_비밀번호_재설정_페이지로_이동_검사() throws Exception {
+        String token = "testToken-1234-5678";
+        given(findCredentialService.getData(token)).willReturn("kernel360-testId");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/member/reset-password?token="+token)
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(token))
+               .andExpect(MockMvcResultMatchers.status().isFound()).andDo(document(
+                       "member/get-reset-password", getDocumentRequest(), getDocumentResponse(),
+                       queryParameters(
+                               parameterWithName("token").description("비밀번호 재설정 UUID 토큰")
+                       ),
+                       responseFields(
+                               fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                               fieldWithPath("code").type(JsonFieldType.STRING).description("비즈니스 코드"),
+                               fieldWithPath("message").type(JsonFieldType.STRING).description("상세 메시지"),
+                               fieldWithPath("value").type(JsonFieldType.STRING).description("JSON BODY 데이터 - 비밀번호 재설정 토큰")
+                       )
+               ));
+    }
+
+    @Test
+    @DisplayName("재설정할 비밀번호와 재설정 토큰을 입력받아 비밀번호 재설정에 성공한다")
+    void 비밀번호_재설정_검사() throws Exception{
+        MemberCredentialDto credentialDto = MemberCredentialDto.of("testToken", null, null, "resetPassword");
+        given(findCredentialService.resetPassword(credentialDto)).willReturn("testToken");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String dtoAsString = objectMapper.writeValueAsString(credentialDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/member/reset-password")
+                                              .contentType(MediaType.APPLICATION_JSON)
+                                              .content(dtoAsString))
+               .andExpect(MockMvcResultMatchers.status().isOk())
+               .andDo(document(
+                       "member/post-reset-password", getDocumentRequest(), getDocumentResponse(),
+                       requestFields(
+                               fieldWithPath("authToken").type(JsonFieldType.STRING).description("비밀번호 재설정 UUID 토큰"),
+                               fieldWithPath("email").type(JsonFieldType.NULL).description("회원가입시 입력한 이메일(사용하지 않음)"),
+                               fieldWithPath("memberId").type(JsonFieldType.NULL).description("회원 아이디(사용하지 않음)"),
+                               fieldWithPath("password").type(JsonFieldType.STRING).description("변경할 비밀번호")
+                       ),
+                       responseFields(
+                               fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                               fieldWithPath("code").type(JsonFieldType.STRING).description("비즈니스 코드"),
+                               fieldWithPath("message").type(JsonFieldType.STRING).description("상세 메시지"),
+                               fieldWithPath("value").type(JsonFieldType.NULL).description("JSON BODY 데이터")
+                       )
+               ));
     }
 }
+

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -4,7 +4,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kernel360.common.ControllerTest;
-import com.kernel360.member.dto.FindMemberIdFromEmailDto;
+import com.kernel360.member.dto.MemberCredentialDto;
 import com.kernel360.member.dto.MemberDto;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -102,7 +102,7 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("이메일을 입력 받아 아이디 찾기 이메일 발송")
     void 아이디_찾기_이메일_발송_검사() throws Exception {
         /** given 목데이터 세팅 **/
-        FindMemberIdFromEmailDto dto = FindMemberIdFromEmailDto.of("kernel360@gmail.com");
+        MemberCredentialDto dto = MemberCredentialDto.of(null, "kernel360@gmail.com", null, null);
         MemberDto memberDto = MemberDto.of("testMemberId", "testPassword001");
 
         given(memberService.findByEmail(dto.email())).willReturn(memberDto);

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -146,10 +146,9 @@ class MemberControllerTest extends ControllerTest {
         // given
         MemberCredentialDto credentialDto = MemberCredentialDto.of(null, null, "kernel360", null);
         MemberDto memberDto = MemberDto.of("testMemberId", "testPassword001");
-        MockHttpServletRequest request = new MockHttpServletRequest();
 
         given(memberService.findByMemberId(credentialDto.memberId())).willReturn(memberDto);
-        given(findCredentialService.generatePasswordResetUri(request, memberDto)).willReturn("테스트 URI");
+        given(findCredentialService.generatePasswordResetUri(memberDto)).willReturn("테스트 URI");
 
         ObjectMapper objectMapper = new ObjectMapper();
         String dtoAsString = objectMapper.writeValueAsString(credentialDto);


### PR DESCRIPTION
## 💡 Motivation and Context
`비밀번호를 분실한 회원이 비밀번호를 재설정 할 수 있는 기능을 추가합니다.`

<br>

## 🔨 Modified
> 비밀번호를 분실한 경우, 회원 아이디를 통해 비밀번호를 재설정할 수 있도록 합니다.
  - _`회원 아이디`로 `비밀번호 찾기 요청`을 합니다._
  - _아이디를 통해 회원가입시 입력한 이메일를 조회합니다_
  - _해당 이메일로 비밀번호 재설정이 가능한 `URL 링크`를 발송합니다_
      - _링크에는 5분간 유효한 `UUID` 토큰이 포함되어 있습니다._
      -  _토큰은 `Redis`에 저장되어 `유효시간이 지나면 자동으로 사라집니다`._
  - 이메일에서 URL 링크를 클릭하면 먼저 서버에 요청을 보냅니다
      - 서버에서는 요청의 쿼리 파라미터로 포함된 `UUID` 토큰이 유효한지 판단합니다.
      - 유효하다면  비밀번호 재설정이 가능한 화면으로 이동합니다.
  - 재설정 화면에서 변경할 비밀번호와 토큰을 전달합니다.
      - 토큰 유효성을 다시 확인하고 비밀번호를 재설정합니다.
      - 이후 사용된 토큰을 폐기합니다.
      - 
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/ae5fdd82-4369-4e8e-8f88-bbc9db493024)

> 이메일을 발송하는 서비스와, 실제 아이디/비밀번호 찾기를 수행하는 서비스를 분리하였습니다.

> 아이디/비밀번호 찾기에 사용되는 DTO 클래스를 `MemberCredentialDto.java` 로 통합하였습니다.

<br>

## 🌟 More
- _Redis 관련 클래스들을 현재 api 모듈에 두었는데(api 모듈에서 인증관련으로만 사용하니까), domain 모듈에 두어야 하는지 고민하고 있습니다._
- _Member 를 조회할 때 지연로딩이 동작하지 않고 carInfo, washInfo 를 즉시로딩하여 가져오고 있습니다. 엔티티의 연관관계 코드를 보면 지연로딩을 사용하도록 의도하신 것 같은데 이 부분을 잘 확인하여 연관관계를 리팩터링 할 필요가 있습니다._

<br>

---


### 📋 커밋 전 체크리스트
- [x] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #158
