### PR TITLE
feat :: Exception 처리 추가

### DIFF
--- a/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
@@ -20,7 +20,7 @@ public class AcceptInterceptor implements HandlerInterceptor {
         boolean result = true;
         String requestToken = request.getHeader("Authorization");
 
-        if (StringUtils.hasLength(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.DOSE_NOT_EXIST_REQUEST_TOKEN); }
+        if (!StringUtils.hasLength(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.DOSE_NOT_EXIST_REQUEST_TOKEN); }
 
         if (!authService.validRequestToken(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN); }
 

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
@@ -19,11 +20,11 @@ public class AcceptInterceptor implements HandlerInterceptor {
         boolean result = true;
         String requestToken = request.getHeader("Authorization");
 
-        if (requestToken.length() == 0) { throw new BusinessException(AcceptInterceptorErrorCode.DOSE_NOT_EXIST_REQUEST_TOKEN); }
+        if (StringUtils.hasLength(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.DOSE_NOT_EXIST_REQUEST_TOKEN); }
 
         if (!authService.validRequestToken(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN); }
 
-        //IP수집 후 테이블에 저장
+        // TODO:: IP 수집 후 테이블에 저장 -> 토큰 갱신 요청시 확인해서 토큰 재발급
 
         return result;
     }

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
@@ -13,7 +13,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(acceptInterceptor)
-                .addPathPatterns("/auth/validToken");
+                .addPathPatterns("/auth/**");
 //                .addPathPatterns("/mypage/**");
                 //.excludePathPatterns("/public/**"); // 제외할 URL 패턴
     }

--- a/module-api/src/main/java/com/kernel360/main/controller/MainController.java
+++ b/module-api/src/main/java/com/kernel360/main/controller/MainController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping
 @RequiredArgsConstructor
-public class MainContoller {
+public class MainController {
     private final ProductService productService;
     private final MainService mainService;
 

--- a/module-api/src/main/java/com/kernel360/member/code/MemberErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/member/code/MemberErrorCode.java
@@ -16,7 +16,8 @@ public enum MemberErrorCode implements ErrorCode {
     FAILED_FIND_MEMBER_INFO(HttpStatus.BAD_REQUEST.value(), "EMC007", "요청 회원정보가 존재하지 않습니다."),
     EXPIRED_PASSWORD_RESET_TOKEN(HttpStatus.NOT_FOUND.value(), "EMC008", "유효하지 않은 비밀번호 초기화 토큰입니다"),
     FAILED_REQUEST_LOGIN_FOR_KAKAO(HttpStatus.BAD_REQUEST.value(), "EMC009", "카카오 로그인 정보를 찾을 수 없습니다."),
-    FAILED_DUPLICATED_JOIN_MEMBER_INFO(HttpStatus.BAD_REQUEST.value(), "EMC010", "동일한 아이디로 가입한 회원이 이미 존재합니다.");
+    FAILED_DUPLICATED_JOIN_MEMBER_INFO(HttpStatus.BAD_REQUEST.value(), "EMC010", "동일한 아이디로 가입한 회원이 이미 존재합니다."),
+    FAILED_FIND_MEMBER_CAR_INFO(HttpStatus.NOT_FOUND.value(), "EMC011","요청한 회원의 차량정보가 존재하지 않습니다.");
 
     private final int status;
     private final String code;

--- a/module-api/src/main/java/com/kernel360/member/code/MemberErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/member/code/MemberErrorCode.java
@@ -9,13 +9,14 @@ public enum MemberErrorCode implements ErrorCode {
 
     FAILED_NOT_MAPPING_ORDINAL_TO_NAME(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC001", "DB값과 ENUM의 ORDINAL이 불일치하여 NAME을 찾을 수 없음."),
     FAILED_NOT_MAPPING_ORDINAL_TO_VALUE(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC002", "DB값과 ENUM의 VALUE가 불일치하여 VALUE을 찾을 수 없음."),
-    FAILED_NOT_MAPPING_ENUM_VALUEOF(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC003", "PARAMETER 값과 ENUM의 NAME이 불일치함."),
+    FAILED_NOT_MAPPING_ENUM_VALUE_OF(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC003", "PARAMETER 값과 ENUM의 NAME이 불일치함."),
     FAILED_GENERATE_JOIN_MEMBER_INFO(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC004", "회원가입에 필요한 정보 생성 실패"),
     FAILED_GENERATE_LOGIN_REQUEST_INFO(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EMC005", "정보 불일치로 인한 로그인 정보 생성 실패"),
     FAILED_REQUEST_LOGIN(HttpStatus.BAD_REQUEST.value(), "EMC006", "정보 불일치로 인한 로그인 실패"),
     FAILED_FIND_MEMBER_INFO(HttpStatus.BAD_REQUEST.value(), "EMC007", "요청 회원정보가 존재하지 않습니다."),
     EXPIRED_PASSWORD_RESET_TOKEN(HttpStatus.NOT_FOUND.value(), "EMC008", "유효하지 않은 비밀번호 초기화 토큰입니다"),
-    FAILED_REQUEST_LOGIN_FOR_KAKAO(HttpStatus.BAD_REQUEST.value(), "EMC009", "카카오 로그인 정보를 찾을 수 없습니다.");
+    FAILED_REQUEST_LOGIN_FOR_KAKAO(HttpStatus.BAD_REQUEST.value(), "EMC009", "카카오 로그인 정보를 찾을 수 없습니다."),
+    FAILED_DUPLICATED_JOIN_MEMBER_INFO(HttpStatus.BAD_REQUEST.value(), "EMC010", "동일한 아이디로 가입한 회원이 이미 존재합니다.");
 
     private final int status;
     private final String code;

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -42,7 +42,8 @@ public class MemberService {
     public void joinMember(MemberDto requestDto) {
         Member entity = getNewJoinMemberEntity(requestDto);
         if (entity == null) {   throw new BusinessException(MemberErrorCode.FAILED_GENERATE_JOIN_MEMBER_INFO);  }
-
+        // TODO :: ControllerAdvice 추가 고민해보기
+        if(memberRepository.findOneById(entity.getId()) != null){ throw new BusinessException(MemberErrorCode.FAILED_DUPLICATED_JOIN_MEMBER_INFO);}
         memberRepository.save(entity);
     }
 
@@ -55,7 +56,7 @@ public class MemberService {
             genderOrdinal = Gender.valueOf(requestDto.gender()).ordinal();
             ageOrdinal = Age.valueOf(requestDto.age()).ordinal();
         } catch (Exception e) {
-            throw new BusinessException(MemberErrorCode.FAILED_NOT_MAPPING_ENUM_VALUEOF);
+            throw new BusinessException(MemberErrorCode.FAILED_NOT_MAPPING_ENUM_VALUE_OF);
         }
 
         return Member.createJoinMember(requestDto.id(), requestDto.email(), encodePassword, genderOrdinal, ageOrdinal);

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -141,6 +141,9 @@ public class MemberService {
     public Map<String, Object> getCarInfo(String token) {
         String id = JWT.ownerId(token);
         Member member = memberRepository.findOneById(id);
+        if(member.getCarInfo() == null){
+            throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_CAR_INFO);
+        }
         CarInfoDto carInfoDto = CarInfoDto.from(member.getCarInfo());
 
         return Map.of(

--- a/module-api/src/test/java/com/kernel360/common/ControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/common/ControllerTest.java
@@ -6,7 +6,7 @@ import com.kernel360.auth.service.AuthService;
 import com.kernel360.commoncode.controller.CommonCodeController;
 import com.kernel360.commoncode.service.CommonCodeService;
 import com.kernel360.global.Interceptor.AcceptInterceptor;
-import com.kernel360.main.controller.MainContoller;
+import com.kernel360.main.controller.MainController;
 import com.kernel360.main.service.MainService;
 import com.kernel360.member.controller.MemberController;
 import com.kernel360.member.service.FindCredentialService;
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
         CommonCodeController.class,
         MemberController.class,
         ProductController.class,
-        MainContoller.class,
+        MainController.class,
         MyPageController.class,
         AuthController.class
 })

--- a/module-api/src/test/java/com/kernel360/main/controller/MainControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/main/controller/MainControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-class MainContollerTest extends ControllerTest {
+class MainControllerTest extends ControllerTest {
     private FixtureMonkey fixtureMonkey;
 
     @BeforeEach


### PR DESCRIPTION
## 💡 Motivation and Context
`빈번히 발생하는 Exception 관련하여 처리 로직을 추가하였습니다`

<br>

## 🔨 Modified
> 예외처리 추가
  - _중복된 회원정보를 사유로 회원 가입 실패시 예외발생 -> `FAILED_DUPLICATED_JOIN_MEMBER_INFO`_
  - _Auth 컨트롤러에서 JWT 토큰 갱신 시도시에 이미 만료된 토큰을 가지고 있을 떄 예외발생 -> `InteceptorConfig` 에 설정 추가_
  - _아직 차량정보를 등록하지 않은 회원이 차량정보조회 요청을 할 때 발생하는 NullPointer -> `FAILED_FIND_MEMBER_CAR_INFO`_

> 오타 수정
- _`MainContoller` -> `MainController`_


<br>

## 🌟 More
- _likeOn → 좋아요가 중복해서 생성되는 문제 해결 필요_
   - 같은 유저의 같은 제품에 대한 좋아요(즐겨찾기)가 중복해서 생성됨. 그 결과 likeOff 의 반환값이 List 가 될 수 있는 문제가 발생함. → 중복생성되지 않게 변경하여야 함
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/0d7720f5-75d5-45fc-9845-6c7dae3a5906)


<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #189
