### PR TITLE
Feature : 로그인 유저에 대한 IP validation 추가

### DIFF
--- a/module-api/src/main/java/com/kernel360/auth/controller/AuthController.java
+++ b/module-api/src/main/java/com/kernel360/auth/controller/AuthController.java
@@ -5,13 +5,16 @@ import com.kernel360.auth.service.AuthService;
 import com.kernel360.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.kernel360.auth.code.AuthBusinessCode.SUCCESS_REQUEST_REGENERATED_JWT;
+import static com.kernel360.auth.service.AuthService.getClientIP;
 
+@Slf4j
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -21,8 +24,7 @@ public class AuthController {
 
     @GetMapping("/reissuanceJWT")
     public ResponseEntity<ApiResponse<AuthDto>> reissuanceJWT(HttpServletRequest request){
-
-        return ApiResponse.toResponseEntity(SUCCESS_REQUEST_REGENERATED_JWT,
-                AuthDto.of(authService.generateTokenAndSaveAuth(request.getHeader("Authorization"))));
+        log.info("Current Client IP :: "+getClientIP(request));
+        return ApiResponse.toResponseEntity(SUCCESS_REQUEST_REGENERATED_JWT, AuthDto.of(authService.generateTokenAndSaveAuth(request)));
     }
 }

--- a/module-api/src/main/java/com/kernel360/auth/service/AuthService.java
+++ b/module-api/src/main/java/com/kernel360/auth/service/AuthService.java
@@ -4,12 +4,13 @@ import com.kernel360.auth.entity.Auth;
 import com.kernel360.auth.repository.AuthRepository;
 import com.kernel360.utils.ConvertSHA256;
 import com.kernel360.utils.JWT;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.Objects;
-import java.util.Optional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -18,10 +19,12 @@ public class AuthService {
 
     private final JWT jwt;
     private final AuthRepository authRepository;
+
     public Auth findOneByMemberNo(Long memberNo) {
 
         return authRepository.findOneByMemberNo(memberNo);
     }
+
     public Auth findOneByJwt(String encryptToken) {
 
         return authRepository.findOneByJwtToken(encryptToken);
@@ -35,38 +38,88 @@ public class AuthService {
         return result;
     }
 
-    public String generateTokenAndSaveAuth(String requestToken) {
-        String newToken = jwt.generateToken(JWT.ownerId(requestToken));
-        Auth storedAuth = authRepository.findOneByJwtToken(ConvertSHA256.convertToSHA256(requestToken));
+    public String generateTokenAndSaveAuth(HttpServletRequest request) {
+        String newToken = jwt.generateToken(JWT.ownerId(request.getHeader("Authorization")));
+        Auth storedAuth = authRepository.findOneByJwtToken(ConvertSHA256.convertToSHA256(request.getHeader("Authorization")));
+        String clientIP = getClientIP(request);
 
-        modifyAuthJwt(storedAuth, ConvertSHA256.convertToSHA256(newToken));
+        modifyAuthJwt(storedAuth, ConvertSHA256.convertToSHA256(newToken), clientIP);
 
         authRepository.save(storedAuth);
 
         return newToken;
     }
 
-    // TODO refactor :: auth의 pk로 인해 조회 후 update - insert 를 결정하게 되어 줄일 필요가 있음. memberNo만으로 키를 잡는다면, flyway 또 수정해야함... 혹은 인증은 memorydb를 쓰는 방법 고려
-    public void saveAuthByMember(Long memberNo, String encryptToken) {
+    // TODO refactor :: auth 의 pk로 인해 조회 후 update - insert 를 결정하게 되어 줄일 필요가 있음. memberNo만으로 키를 잡는다면, flyway 또 수정해야함... 혹은 인증은 memorydb를 쓰는 방법 고려
+    public void saveAuthByMember(Long memberNo, String encryptToken, HttpServletRequest request) {
         Auth authJwt = findOneByMemberNo(memberNo);
+        String clientIP = getClientIP(request);
 
-        //결과 없으면 entity로 신규 생성
+        //결과 없으면 entity 로 신규 생성
         authJwt = Optional.ofNullable(authJwt)
-                          .map(modifyAuth -> modifyAuthJwt(modifyAuth, encryptToken))
-                          .orElseGet(() -> createAuthJwt(memberNo, encryptToken));
+                          .map(modifyAuth -> modifyAuthJwt(modifyAuth, encryptToken, clientIP))
+                          .orElseGet(() -> createAuthJwt(memberNo, encryptToken, clientIP));
 
         authRepository.save(authJwt);
     }
 
-    public Auth createAuthJwt(Long memberNo, String encryptToken) {
+    public Auth createAuthJwt(Long memberNo, String encryptToken, String clientIP) {
 
-        return Auth.of(null, memberNo, encryptToken, null);
+        return Auth.of(null, memberNo, encryptToken, null, clientIP);
     }
 
-    public Auth modifyAuthJwt(Auth modifyAuth, String encryptToken) {
-        modifyAuth.updateJwt(encryptToken);
+    public Auth modifyAuthJwt(Auth modifyAuth, String encryptToken, String clientIP) {
+        modifyAuth.updateJwt(encryptToken, clientIP);
 
         return modifyAuth;
     }
 
+    /**
+     * @param request HttpServletRequest
+     * @return 로그인한 유저이고, 로그인한 IP 와 같으면 참을 반환, 그 이외에는 거짓을 반환
+     */
+    public boolean verifyClientIP(HttpServletRequest request) {
+        String clientIP = getClientIP(request);
+        if (!StringUtils.hasLength(request.getHeader("Authorization"))) { // 인증 토큰이 없는 경우(로그인 하지 않은 유저의 경우)
+            return true;
+        }
+
+        // 인증 토큰이 있고 ip 주소가 같은 경우 true
+        if (StringUtils.hasLength(request.getHeader("Authorization"))) {
+            Auth auth = authRepository.findOneByJwtToken(
+                    ConvertSHA256.convertToSHA256(request.getHeader("Authorization")));
+            return auth.getClientIP().equals(clientIP);
+        }
+        // 그 이외 false
+        return false;
+    }
+
+    public static String getClientIP(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        log.info("> X-FORWARDED-FOR : " + ip);
+
+        if (!StringUtils.hasLength(ip) || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+            log.info("> Proxy-Client-IP : " + ip);
+        }
+        if (!StringUtils.hasLength(ip) || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+            log.info(">  WL-Proxy-Client-IP : " + ip);
+        }
+        if (!StringUtils.hasLength(ip) || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+            log.info("> HTTP_CLIENT_IP : " + ip);
+        }
+        if (!StringUtils.hasLength(ip) || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+            log.info("> HTTP_X_FORWARDED_FOR : " + ip);
+        }
+        if (!StringUtils.hasLength(ip) || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+            log.info("> getRemoteAddr : " + ip);
+        }
+        log.info("> Result : IP Address : " + ip);
+
+        return ip;
+    }
 }

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/AcceptInterceptor.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class AcceptInterceptor implements HandlerInterceptor {
 
     private final AuthService authService;
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         boolean result = true;
@@ -24,7 +25,10 @@ public class AcceptInterceptor implements HandlerInterceptor {
 
         if (!authService.validRequestToken(requestToken)) { throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VALID_REQUEST_TOKEN); }
 
-        // TODO:: IP 수집 후 테이블에 저장 -> 토큰 갱신 요청시 확인해서 토큰 재발급
+        //** 로그인한 IP와 다른 IP로 JWT 갱신을 시도하는 경우 **//
+        if (!authService.verifyClientIP(request)) {
+            throw new BusinessException(AcceptInterceptorErrorCode.FAILED_VERIFY_REQUEST_CLIENT_IP);
+        }
 
         return result;
     }

--- a/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/Interceptor/InterceptorConfig.java
@@ -13,7 +13,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(acceptInterceptor)
-                .addPathPatterns("/auth/**");
+                .addPathPatterns("/auth/**"); //** 인증 JWT 토큰 관련 **//
 //                .addPathPatterns("/mypage/**");
                 //.excludePathPatterns("/public/**"); // 제외할 URL 패턴
     }

--- a/module-api/src/main/java/com/kernel360/global/code/AcceptInterceptorErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/global/code/AcceptInterceptorErrorCode.java
@@ -10,7 +10,8 @@ public enum AcceptInterceptorErrorCode implements ErrorCode {
     DOSE_NOT_EXIST_REQUEST_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AIEC001", "요청자의 토큰이 존재하지 않음."),
     FAILED_VALID_REQUEST_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AIEC002", "요청자의 토큰이 유효하지 않음."),
     FAILED_VALID_REQUEST_TOKEN_PERIOD(HttpStatus.BAD_REQUEST.value(), "AIEC003", "토큰 유효시간 조건이 충족되지 않음."),
-    FAILED_VALID_REQUEST_TOKEN_HASH(HttpStatus.BAD_REQUEST.value(), "AIEC004", "로그인시 발급한 토큰의 해시값과 불일치함.");
+    FAILED_VALID_REQUEST_TOKEN_HASH(HttpStatus.BAD_REQUEST.value(), "AIEC004", "로그인시 발급한 토큰의 해시값과 불일치함."),
+    FAILED_VERIFY_REQUEST_CLIENT_IP(HttpStatus.UNAUTHORIZED.value(), "AIEC005","로그인시 IP 주소와 불일치함");
 
     private final int status;
     private final String code;

--- a/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
+++ b/module-api/src/main/java/com/kernel360/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import com.kernel360.member.service.FindCredentialService;
 import com.kernel360.member.service.MemberService;
 import com.kernel360.response.ApiResponse;
 import com.kernel360.washinfo.entity.WashInfo;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -39,9 +40,9 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<MemberDto>> login(@RequestBody MemberDto loginDto) {
+    public ResponseEntity<ApiResponse<MemberDto>> login(@RequestBody MemberDto loginDto, HttpServletRequest request) {
 
-        MemberDto memberInfo = memberService.login(loginDto);
+        MemberDto memberInfo = memberService.login(loginDto, request);
 
         //부가정보가 입력 되어있는가 > 차량정보, 세차정보, boolean (감싸서 보내든 말든 노상관)
 
@@ -111,9 +112,9 @@ public class MemberController {
     }
 
     @GetMapping("/login/forKakao")
-    public ResponseEntity<ApiResponse<MemberDto>> loginForKakao(@RequestHeader("Authorization") String accessToken) {
+    public ResponseEntity<ApiResponse<MemberDto>> loginForKakao(@RequestHeader("Authorization") String accessToken,HttpServletRequest request) {
 
-        MemberDto member = memberService.loginForKakao(accessToken);
+        MemberDto member = memberService.loginForKakao(accessToken,request);
 
         return ApiResponse.toResponseEntity(SUCCESS_REQUEST_LOGIN_MEMBER, member);
     }

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -15,15 +15,15 @@ import com.kernel360.utils.ConvertSHA256;
 import com.kernel360.utils.JWT;
 import com.kernel360.washinfo.entity.WashInfo;
 import com.kernel360.washinfo.repository.WashInfoRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestHeader;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 
 @Slf4j
@@ -64,21 +64,23 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberDto login(MemberDto loginDto) {
-        Member loginEntity = newReqeustLoginEntity(loginDto);
-        if (Objects.isNull(loginEntity)) { throw new BusinessException(MemberErrorCode.FAILED_GENERATE_LOGIN_REQUEST_INFO);    }
+    public MemberDto login(MemberDto loginDto, HttpServletRequest request) {
+        Member loginEntity = newRequestLoginEntity(loginDto);
+        if (Objects.isNull(loginEntity)) {
+            throw new BusinessException(MemberErrorCode.FAILED_GENERATE_LOGIN_REQUEST_INFO);
+        }
 
         Member memberEntity = memberRepository.findOneByIdAndPassword(loginEntity.getId(), loginEntity.getPassword());
         if (Objects.isNull(memberEntity)) { throw new BusinessException(MemberErrorCode.FAILED_REQUEST_LOGIN);  }
 
         String loginToken = jwt.generateToken(memberEntity.getId());
 
-        authService.saveAuthByMember(memberEntity.getMemberNo(), ConvertSHA256.convertToSHA256(loginToken));
+        authService.saveAuthByMember(memberEntity.getMemberNo(), ConvertSHA256.convertToSHA256(loginToken), request);
 
         return MemberDto.login(memberEntity, loginToken);
     }
 
-    private Member newReqeustLoginEntity(MemberDto loginDto) {
+    private Member newRequestLoginEntity(MemberDto loginDto) {
         String encodePassword = ConvertSHA256.convertToSHA256(loginDto.password());
 
         return Member.loginMember(loginDto.id(), encodePassword);
@@ -131,8 +133,9 @@ public class MemberService {
         String id = JWT.ownerId(token);
         Member member = memberRepository.findOneById(id);
 
-        if ( !member.getPassword().equals(ConvertSHA256.convertToSHA256(password)))
+        if (!member.getPassword().equals(ConvertSHA256.convertToSHA256(password))) {
             throw new BusinessException(MemberErrorCode.WRONG_PASSWORD_REQUEST);
+        }
 
         member.updatePassword(ConvertSHA256.convertToSHA256(password));
         log.info("{} 회원의 비밀번호가 변경되었습니다.", id);
@@ -170,8 +173,9 @@ public class MemberService {
     public Optional<WashInfoDto> getWashInfo(String token) {
         String id = JWT.ownerId(token);
         Member member = memberRepository.findOneById(id);
-        if (member == null)
+        if (member == null) {
             throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);
+        }
 
         return Optional.of(WashInfoDto.from(member.getWashInfo()));
     }
@@ -180,7 +184,8 @@ public class MemberService {
     public void saveWashInfo(WashInfoDto washInfoDto, String token) {
         String id = JWT.ownerId(token);
         Member member = memberRepository.findOneById(id);
-        WashInfo washInfo = WashInfo.of(washInfoDto.washNo(), washInfoDto.washCount(), washInfoDto.monthlyExpense(), washInfoDto.interest());
+        WashInfo washInfo = WashInfo.of(washInfoDto.washNo(), washInfoDto.washCount(), washInfoDto.monthlyExpense(),
+                washInfoDto.interest());
         washInfo.settingMember(member);
         member.updateWashInfo(washInfo);
 
@@ -191,7 +196,8 @@ public class MemberService {
     public void saveCarInfo(CarInfoDto carInfoDto, String token) {
         String id = JWT.ownerId(token);
         Member member = memberRepository.findOneById(id);
-        CarInfo carInfo = CarInfo.of(carInfoDto.carType(), carInfoDto.carSize(), carInfoDto.carColor(), carInfoDto.drivingEnv(), carInfoDto.parkingEnv());
+        CarInfo carInfo = CarInfo.of(carInfoDto.carType(), carInfoDto.carSize(), carInfoDto.carColor(),
+                carInfoDto.drivingEnv(), carInfoDto.parkingEnv());
         carInfo.settingMember(member);
         member.updateCarInfo(carInfo);
 
@@ -217,7 +223,7 @@ public class MemberService {
 
         return MemberDto.from(member);
     }
-  
+
     @Transactional
     public void resetPasswordByMemberId(String memberId, String newPassword) {
         Member member = memberRepository.findOneById(memberId);
@@ -229,18 +235,20 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberDto loginForKakao(String accessToken) {
+    public MemberDto loginForKakao(String accessToken, HttpServletRequest request) {
 
         KakaoUserDto kakaoUser = kakaoRequest.getKakaoUserByToken(accessToken);
         if (Objects.isNull(memberRepository.findOneById(kakaoUser.id()))) {
-            memberRepository.save(Member.createForKakao(kakaoUser.id(), kakaoUser.email(), "kakao", Gender.OTHERS.ordinal(), Age.AGE_99.ordinal()));
+            memberRepository.save(
+                    Member.createForKakao(kakaoUser.id(), kakaoUser.email(), "kakao", Gender.OTHERS.ordinal(),
+                            Age.AGE_99.ordinal()));
         }
 
         MemberDto memberDto = MemberDto.from(memberRepository.findOneById(kakaoUser.id()));
 
         String loginToken = jwt.generateToken(memberDto.id());
 
-        authService.saveAuthByMember(memberDto.memberNo(), ConvertSHA256.convertToSHA256(loginToken));
+        authService.saveAuthByMember(memberDto.memberNo(), ConvertSHA256.convertToSHA256(loginToken), request);
 
         return MemberDto.fromKakao(memberDto, loginToken);
     }

--- a/module-api/src/main/resources/db/migration/V1.0.9__add_clientIP_to_auth.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.9__add_clientIP_to_auth.sql
@@ -1,0 +1,2 @@
+ALTER TABLE auth
+    ADD COLUMN client_ip varchar;

--- a/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
@@ -12,50 +12,48 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.kernel360.auth.dto.AuthDto;
 import com.kernel360.common.ControllerTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MvcResult;
 
-@Disabled
 @AutoConfigureWebMvc
 class AuthControllerTest extends ControllerTest {
-
     @Test
     void 토큰_갱신요청이_왔을때_리스폰스로_상태코드201과_갱신토큰이_잘_보내지는지() throws Exception {
         String requestToken = "token";
         String resultToken = "reissuanceToken";
+        AuthDto dto = new AuthDto(resultToken);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader("Authorization",requestToken);
+        when(acceptInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        when(authService.generateTokenAndSaveAuth(any())).thenReturn(resultToken);
 
-        when(authService.generateTokenAndSaveAuth(request))
-                .thenReturn(resultToken);
+        try (MockedStatic<AuthDto> mocked = Mockito.mockStatic(AuthDto.class)) {
+            mocked.when(() -> AuthDto.of(resultToken)).thenReturn(dto);
 
-        when(acceptInterceptor.preHandle(any(), any(),
-                any())).thenReturn(true);
-
-        when(authService.generateTokenAndSaveAuth(request)).thenReturn(resultToken);
-
-        mockMvc.perform(get("/auth/reissuanceJWT")
-                       .header("Authorization", requestToken))
-               .andExpect(status().isCreated())
-               .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-               .andExpect(jsonPath("$.status").value(201))
-               .andExpect(jsonPath("$.code").value("BAC001"))
-               .andExpect(jsonPath("$.message").value("JWT 토큰 재발급 성공"))
-               .andDo(document("auth/reissuanceJWT",
-                       getDocumentRequest(),
-                       getDocumentResponse(),
-                       responseFields(
-                               fieldWithPath("status").description("상태 코드"),
-                               fieldWithPath("message").description("응답 메시지"),
-                               fieldWithPath("code").description("비즈니스 코드"),
-                               fieldWithPath("value.jwtToken").type(JsonFieldType.STRING).description("JWT토큰")
-                       )))
-               .andReturn();
+            MvcResult actions = mockMvc.perform(get("/auth/reissuanceJWT")
+                                               .header("Authorization", requestToken))
+                                       .andExpect(status().isCreated())
+                                       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                                       .andExpect(jsonPath("$.status").value(201))
+                                       .andExpect(jsonPath("$.code").value("BAC001"))
+                                       .andExpect(jsonPath("$.message").value("JWT 토큰 재발급 성공"))
+                                       .andDo(document("auth/reissuanceJWT",
+                                               getDocumentRequest(),
+                                               getDocumentResponse(),
+                                               responseFields(
+                                                       fieldWithPath("status").description("상태 코드"),
+                                                       fieldWithPath("message").description("응답 메시지"),
+                                                       fieldWithPath("code").description("비즈니스 코드"),
+                                                       fieldWithPath("value.jwtToken").type(JsonFieldType.STRING)
+                                                                                      .description("JWT 토큰")
+                                               )))
+                                       .andReturn();
+        }
     }
 }

--- a/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/auth/controller/AuthControllerTest.java
@@ -17,23 +17,28 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 @Disabled
 @AutoConfigureWebMvc
 class AuthControllerTest extends ControllerTest {
 
-
     @Test
     void 토큰_갱신요청이_왔을때_리스폰스로_상태코드201과_갱신토큰이_잘_보내지는지() throws Exception {
         String requestToken = "token";
         String resultToken = "reissuanceToken";
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization",requestToken);
+
+        when(authService.generateTokenAndSaveAuth(request))
+                .thenReturn(resultToken);
+
         when(acceptInterceptor.preHandle(any(), any(),
                 any())).thenReturn(true);
 
-        when(authService.generateTokenAndSaveAuth(requestToken))
-                .thenReturn(resultToken);
+        when(authService.generateTokenAndSaveAuth(request)).thenReturn(resultToken);
 
         mockMvc.perform(get("/auth/reissuanceJWT")
                        .header("Authorization", requestToken))

--- a/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/member/controller/MemberControllerTest.java
@@ -47,7 +47,7 @@ class MemberControllerTest extends ControllerTest {
     @Test
     @DisplayName("아이디_비밀번호를_받아_로그인_성공시_200반환")
     void 로그인() throws Exception {
-
+        // given
         MemberDto memberDto = MemberDto.of("testID", "testPassword");
         MemberDto memberInfo = new MemberDto(1L,
                 "test01",
@@ -61,10 +61,13 @@ class MemberControllerTest extends ControllerTest {
                 null,
                 "dummyToken"
         );
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
         ObjectMapper objectMapper = new ObjectMapper();
         String param = objectMapper.writeValueAsString(memberDto);
 
-        given(memberService.login(memberDto)).willReturn(memberInfo);
+        given(memberService.login(memberDto, request)).willReturn(memberInfo);
 
         /** then **/
         mockMvc.perform(MockMvcRequestBuilders.post("/member/login")

--- a/module-domain/src/main/java/com/kernel360/auth/entity/Auth.java
+++ b/module-domain/src/main/java/com/kernel360/auth/entity/Auth.java
@@ -1,7 +1,13 @@
 package com.kernel360.auth.entity;
 
 import com.kernel360.base.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,23 +34,27 @@ public class Auth extends BaseEntity {
     @Column(name = "sns_token")
     private String snsToken;
 
+    @Column(name = "client_ip")
+    private String clientIP;
+
 
     /**
      * all create
      **/
-    public static Auth of(Long authNo, Long memberNo, String jwtToken, String snsToken) {
+    public static Auth of(Long authNo, Long memberNo, String jwtToken, String snsToken, String clientIP) {
 
-        return new Auth(authNo, memberNo, jwtToken, snsToken);
+        return new Auth(authNo, memberNo, jwtToken, snsToken, clientIP);
     }
 
     /**
      * all binding
      **/
-    private Auth(Long authNo, Long memberNo, String jwtToken, String snsToken) {
+    private Auth(Long authNo, Long memberNo, String jwtToken, String snsToken, String clientIP) {
         this.authNo = authNo;
         this.memberNo = memberNo;
         this.jwtToken = jwtToken;
         this.snsToken = snsToken;
+        this.clientIP = clientIP;
     }
 
 
@@ -62,8 +72,9 @@ public class Auth extends BaseEntity {
         this.jwtToken = jwtToken;
     }
 
-    public void updateJwt(String encryptToken) {
+    public void updateJwt(String encryptToken, String clientIP) {
         this.jwtToken = encryptToken;
+        this.clientIP = clientIP;
     }
 
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`로그인 유저에 대한 IP validation 추가`

<br>

## 🔨 Modified
> IP validation 추가
  - _로그인을 하며 JWT 토큰을 생성할 때, 클라이언트의 IP 주소를 동시에 수집합니다._
  - _이후 로그인 한 유저가 JWT 갱신을 요청할 때, 요청의 IP 주소와 로그인 시 수집했던 IP 주소를 비교합니다_
  - _서로 같은 IP일 경우 요청을 승인하고, 그렇지 않을 경우 요청을 거부하고 401 응답을 반환합니다_
     
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/0ef779b3-983a-4e21-b639-070dc1da699c)
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/35c9e4b6-48db-47a6-98ab-aa31b7fd0ea9)


<br>

## 🌟 More
- _IP 주소를 비교하기 때문에, 로그인 한 이후 모바일 환경이나 wifi 등의 이슈로 IP 주소가 변경되는 경우 JWT 갱신에 실패하게 됩니다._
- 따라서, IP 그룹별로 validation 을 하거나, 지역기반으로 validation 을 하는 방법으로 refactoring 이 필요합니다

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #194'
