### PR TITLE
refactor:: 즐겨찾기 목록 요청 리팩토링

### DIFF
--- a/module-domain/src/main/java/com/kernel360/likes/entity/Like.java
+++ b/module-domain/src/main/java/com/kernel360/likes/entity/Like.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "likes")
+@Table(name = "likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_no", "product_no"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like extends BaseEntity {
     @Id


### PR DESCRIPTION
## 💡 Motivation and Context

- refactor:: 즐겨찾기 목록 요청 리팩토링
<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - 즐겨찾기 목록이 존재하지 않을때, 에러를 던지는 대신, 빈 Page 객체를 리턴하도록 변경
<br>

<img width="402" alt="image" src="https://github.com/Kernel360/F1-WashPedia-BE/assets/91066575/4e63bba2-fa13-493a-be52-c33ce8a24a70">

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #220 
