### PR TITLE
feature :: 회원가입, 로그인시 계정 타입 추가

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/dto/MemberDto.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/MemberDto.java
@@ -89,7 +89,8 @@ public record MemberDto(Long memberNo,
                 this.email(),
                 this.password(),
                 Gender.valueOf(this.gender()).ordinal(),
-                Age.valueOf(this.age()).ordinal()
+                Age.valueOf(this.age()).ordinal(),
+                null
         );
     }
 

--- a/module-api/src/main/java/com/kernel360/member/enumset/AccountType.java
+++ b/module-api/src/main/java/com/kernel360/member/enumset/AccountType.java
@@ -1,0 +1,5 @@
+package com.kernel360.member.enumset;
+
+public enum AccountType {
+    PLATFORM, KAKAO, NAVER, GOOGLE
+}

--- a/module-api/src/main/java/com/kernel360/mypage/controller/MyPageController.java
+++ b/module-api/src/main/java/com/kernel360/mypage/controller/MyPageController.java
@@ -47,14 +47,12 @@ public class MyPageController {
         return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_FIND_WASH_INFO_IN_MEMBER, washInfoDto);
     }
 
-
     @DeleteMapping("/member")
     ResponseEntity<ApiResponse<Void>> memberDelete(@RequestHeader("Authorization") String authToken) {
         memberService.deleteMemberByToken(authToken);
 
         return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_REQUEST_DELETE_MEMBER);
     }
-
 
     @PostMapping("/member")
     ResponseEntity<ApiResponse<String>> changePassword(@RequestBody String password, @RequestHeader("Authorization") String authToken) {
@@ -68,7 +66,6 @@ public class MyPageController {
 
         return memberService.validatePassword(password.password(), authToken);
     }
-
 
     @PatchMapping("/member")
     <T> ResponseEntity<ApiResponse<T>> updateMember(@RequestBody MemberInfo memberInfo,

--- a/module-api/src/main/resources/db/migration/V1.0.0__init.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.0__init.sql
@@ -25,6 +25,7 @@ CREATE TABLE if not exists Auth
     created_by  varchar   NOT NULL,
     modified_at date      NULL,
     modified_by varchar   NULL
+
 );
 
 
@@ -39,7 +40,8 @@ CREATE TABLE if not exists Member
     created_at  DATE    NOT NULL,
     created_by  VARCHAR NOT NULL,
     modified_at DATE,
-    modified_by VARCHAR
+    modified_by VARCHAR,
+    account_type varchar
 );
 
 

--- a/module-api/src/main/resources/db/migration/V1.0.2__add_member_view_with_secure.sql
+++ b/module-api/src/main/resources/db/migration/V1.0.2__add_member_view_with_secure.sql
@@ -39,7 +39,8 @@ SELECT member_no,
        created_at,
        created_by,
        modified_at,
-       modified_by
+       modified_by,
+       account_type
 FROM member;
 
 
@@ -51,10 +52,10 @@ CREATE
     RETURNS TRIGGER AS
 $$
 BEGIN
-    INSERT INTO member (member_no, id, "password", email, gender, age, created_at, created_by, modified_at, modified_by)
+    INSERT INTO member (member_no, id, "password", email, gender, age, created_at, created_by, modified_at, modified_by, account_type)
     VALUES (nextval('member_member_no_seq'::regclass), NEW.id, pgp_sym_encrypt(NEW.password::TEXT, 'changeRequired'),
             pgp_sym_encrypt(NEW.email::TEXT, 'changeRequired'), NEW.gender, NEW.age, NEW.created_at, NEW.created_by,
-            NEW.modified_at, NEW.modified_by);
+            NEW.modified_at, NEW.modified_by, NEW.account_type);
 
     RETURN NEW;
 
@@ -88,7 +89,8 @@ BEGIN
         created_at  = NEW.created_at,
         created_by  = NEW.created_by,
         modified_at = NEW.modified_at,
-        modified_by = NEW.modified_by
+        modified_by = NEW.modified_by,
+        account_type = NEW.account_type
     WHERE member_no = NEW.member_no;
     RETURN NEW;
 END;
@@ -132,4 +134,4 @@ EXECUTE FUNCTION member_view_delete_trigger();
 
 
 -- 테이블 member 권한 회수 설정
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES ON member FROM wash_admin;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON member FROM wash_admin;

--- a/module-api/src/test/java/com/kernel360/member/entity/MemberTest.java
+++ b/module-api/src/test/java/com/kernel360/member/entity/MemberTest.java
@@ -1,5 +1,6 @@
 package com.kernel360.member.entity;
 
+import com.kernel360.member.enumset.AccountType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ class MemberTest {
         gender = 0;
         age = 3;
 
-        member = Member.of(memberNo, id, email, password, gender, age);
+        member = Member.of(memberNo, id, email, password, gender, age, AccountType.PLATFORM.name());
     }
 
     @Test

--- a/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/member/service/MemberServiceTest.java
@@ -5,6 +5,7 @@ import com.kernel360.auth.repository.AuthRepository;
 import com.kernel360.auth.service.AuthService;
 import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.entity.Member;
+import com.kernel360.member.enumset.AccountType;
 import com.kernel360.member.repository.MemberRepository;
 import com.kernel360.utils.ConvertSHA256;
 import com.kernel360.utils.JWT;
@@ -87,7 +88,7 @@ class MemberServiceTest {
         MemberDto loginDto = MemberDto.of("test03", "1234qwer");
         Member mockLoginEntity = Member.loginMember(loginDto.id(), loginDto.password());
         Member mockEntity = Member.of(502L, loginDto.id(), "test03@naver.com",
-                "0eb9de69892882d54516e03e30098354a2e39cea36adab275b6300c737c942fd", 0, 0);
+                "0eb9de69892882d54516e03e30098354a2e39cea36adab275b6300c737c942fd", 0, 0, AccountType.PLATFORM.name());
         String mockToken = "dummy_token";
 
         /** stub **/
@@ -111,7 +112,7 @@ class MemberServiceTest {
     void 토큰_발급_저장_테스트() {
 
         /** given **/
-        Member memberEntity = Member.of(502L, "test03", null, null, 0, 0);
+        Member memberEntity = Member.of(502L, "test03", null, null, 0, 0, AccountType.PLATFORM.name());
         String mockToken = "mockToken";
         Auth auth = Auth.jwt(null, 502L, mockToken);
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -143,7 +144,7 @@ class MemberServiceTest {
 
         /** given **/
         String id = "test01";
-        Member memberEntity = Member.of(51L, "test01", null, null, 0, 0);
+        Member memberEntity = Member.of(51L, "test01", null, null, 0, 0, AccountType.PLATFORM.name());
 
         /** stub **/
         when(memberRepository.findOneById(anyString())).thenReturn(memberEntity);
@@ -182,7 +183,7 @@ class MemberServiceTest {
 
         /** given **/
         String email = "kernel360@kernel360.co.kr";
-        Member memberEntity = Member.of(51L, "test01", "kernel360@kernel360.co.kr", null, 0, 0);
+        Member memberEntity = Member.of(51L, "test01", "kernel360@kernel360.co.kr", null, 0, 0, AccountType.PLATFORM.name());
 
         /** stub **/
         when(memberRepository.findOneByEmail(anyString())).thenReturn(memberEntity);

--- a/module-domain/src/main/java/com/kernel360/member/entity/Member.java
+++ b/module-domain/src/main/java/com/kernel360/member/entity/Member.java
@@ -41,9 +41,12 @@ public class Member extends BaseEntity {
     @Column(name = "age")
     private int age;
 
-    public static Member of(Long memberNo, String id, String email, String password, int gender, int age) {
+    @Column(name = "account_type")
+    private String accountType;
 
-        return new Member(memberNo, id, email, password, gender, age);
+    public static Member of(Long memberNo, String id, String email, String password, int gender, int age, String accountType) {
+
+        return new Member(memberNo, id, email, password, gender, age, accountType);
     }
 
     /**
@@ -55,7 +58,8 @@ public class Member extends BaseEntity {
             String email,
             String password,
             int gender,
-            int age
+            int age,
+            String accountType
     ) {
         this.memberNo = memberNo;
         this.id = id;
@@ -63,25 +67,27 @@ public class Member extends BaseEntity {
         this.password = password;
         this.gender = gender;
         this.age = age;
+        this.accountType = accountType;
     }
 
     /**
      * joinMember
      **/
-    public static Member createJoinMember(String id, String email, String password, int gender, int age) {
+    public static Member createJoinMember(String id, String email, String password, int gender, int age, String accountType) {
 
-        return new Member(id, email, password, gender, age);
+        return new Member(id, email, password, gender, age, accountType);
     }
 
     /**
      * joinMember Binding
      **/
-    private Member(String id, String email, String password, int gender, int age) {
+    private Member(String id, String email, String password, int gender, int age, String accountType) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.gender = gender;
         this.age = age;
+        this.accountType = accountType;
     }
 
     /**
@@ -110,11 +116,6 @@ public class Member extends BaseEntity {
 
     public void updateCarInfo(CarInfo carInfo) {
         this.carInfo = carInfo;
-    }
-
-    public static Member createForKakao(String id, String email, String password, int gender, int age) {
-
-        return new Member(id, email, password, gender, age);
     }
 
     public void updateFromInfo(int gender, int age) {

--- a/module-domain/src/main/java/com/kernel360/member/entity/WithdrawMember.java
+++ b/module-domain/src/main/java/com/kernel360/member/entity/WithdrawMember.java
@@ -29,9 +29,9 @@ public class WithdrawMember extends BaseEntity {
     private String ip;
 
 
-    public static WithdrawMember of(Long memberNo, String id, String email, String ip) {
+    public static WithdrawMember of(Member member) {
 
-        return new WithdrawMember(memberNo, id, email, ip);
+        return new WithdrawMember(member.getMemberNo(), member.getId(), member.getEmail(), null); //IP정보를 저장한다면 파라메터를 추가해야
     }
 
     private WithdrawMember(


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`

- 카카오 로그인 이후 다른 sns 로그인 추가가 발생시 적절히 로그인이 가능하도록 조치 하였습니다.

[정책]
- 현재 sns 로그인 정책은 폼가입과 다른 각각의 계정으로 취급하고 연동 기능을 지원하지 않습니다.

[SQL]
- 회원테이블에 account_type이 추가되어 쿼리 파일이 수정되었습니다.
- member 테이블과 뷰를 삭제하고 플라이웨이 이력을 다시 작동해야 합니다. 개발서버 회원정보는 백업해두었습니다.
  폼로그인 카카오 로그인 네이버 로그인 전부 같은사람이 시도해도 다른 계정으로 취급합니다.
  
  [코드]
- 회원 탈퇴 코드가 중복으로 작성되어 메서드 병합 처리를 진행 하였습니다.
- 탈퇴 코드 병합을 하면서 of 절 사용의 대한 리팩터링을 예시로 하나 추가하였습니다.
<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - _여기에 세부 변경사항을 설명해주세요_
![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/dd1de6cc-16e5-49e8-938c-e8250f723efe)
OF절 파라메터를 객체 통째로 보내면 코드가 더욱 간결해집니다.

![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/103917282/a8e21935-b90a-436a-899e-56e75fe72b4b)
계정 타입이 추가되었습니다.
<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
- 아이디 찾기, 비밀번호 찾기, 아이디 중복검사, 비밀번호 중복검사시 jpa find 메서드에 accountType.PLATFORM을 추가해서 
플랫폼 회원정보에 한해서만 작동하도록 변경해야 합니다.

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #217 
