### PR TITLE
Hotfix :: 세차 정보 예외 핸들링 추가

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/dto/MemberInfo.java
+++ b/module-api/src/main/java/com/kernel360/member/dto/MemberInfo.java
@@ -1,10 +1,8 @@
 package com.kernel360.member.dto;
 
 
-
-
 public record MemberInfo(
-                         int gender,
-                         int age
+        int gender,
+        int age
 ) {
 }

--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -173,14 +173,17 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<WashInfoDto> getWashInfo(String token) {
+    public WashInfoDto getWashInfo(String token) {
         String id = JWT.ownerId(token);
         Member member = memberRepository.findOneById(id);
         if (member == null) {
             throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO);
         }
-
-        return Optional.of(WashInfoDto.from(member.getWashInfo()));
+        WashInfo washInfo = member.getWashInfo();
+        if(washInfo == null){
+            throw new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_WASH_INFO);
+        }
+        return WashInfoDto.from(washInfo);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/kernel360/mypage/controller/MyPageController.java
+++ b/module-api/src/main/java/com/kernel360/mypage/controller/MyPageController.java
@@ -41,8 +41,7 @@ public class MyPageController {
 
     @GetMapping("/wash")
     ResponseEntity<ApiResponse<WashInfoDto>> myWash(@RequestHeader("Authorization") String authToken) {
-        WashInfoDto washInfoDto = memberService.getWashInfo(authToken)
-                .orElseThrow(() -> new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_WASH_INFO));
+        WashInfoDto washInfoDto = memberService.getWashInfo(authToken);
 
         return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_FIND_WASH_INFO_IN_MEMBER, washInfoDto);
     }


### PR DESCRIPTION
## 💡 Motivation and Context
`세차 정보 예외 핸들링 추가`

<br>

## 🔨 Modified
> 세차 정보 예외 핸들링 추가
  - _세차 정보가 존재하지 않는 회원이 세차 정보를 조회하려 할 때, NullPointerException 이 떨어지며 500이 반환되는 이슈를 수정하였습니다._
  - 이제 400 커스텀 메시지가 반환됩니다.
<img width="363" alt="image" src="https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/0fc7a8bb-4a9a-4c8e-94ec-d561f71dc23b">


<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
