### PR TITLE
Feature : 커스텀 예외 메시지 처리를 추가합니다.

### DIFF
--- a/module-api/src/main/java/com/kernel360/global/config/WebConfig.java
+++ b/module-api/src/main/java/com/kernel360/global/config/WebConfig.java
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowedMethods("*")
                 .allowCredentials(true)
-                .allowedOrigins("https://www.washfit.site", "https://dev.washfit.site")
+                .allowedOrigins("https://www.washfit.site", "https://dev.washfit.site", "http://localhost:3000")
                 .maxAge(3600);
     }
 }

--- a/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
+++ b/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "E001", "Server Error"),
     FAIL_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR.value(), "E002", "파일 업로드 실패"),
-    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "E003", "유효하지 않은 파일 확장자");
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "E003", "유효하지 않은 파일 확장자"),
+    NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND.value(), "E004", "요청한 자원이 존재하지 않음");
 
     private final int status;
     private final String code;

--- a/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
+++ b/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
@@ -7,7 +7,8 @@ public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "E001", "Server Error"),
     FAIL_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR.value(), "E002", "파일 업로드 실패"),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "E003", "유효하지 않은 파일 확장자"),
-    NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND.value(), "E004", "요청한 자원이 존재하지 않음");
+    NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND.value(), "E004", "요청한 자원이 존재하지 않음"),
+    INVALID_REQUEST_HEADERS(HttpStatus.BAD_REQUEST.value(),  "E005", "요청한 헤더가 존재하지 않음");
 
     private final int status;
     private final String code;

--- a/module-common/src/main/java/com/kernel360/code/jwt/JwtErrorCode.java
+++ b/module-common/src/main/java/com/kernel360/code/jwt/JwtErrorCode.java
@@ -1,0 +1,33 @@
+package com.kernel360.code.jwt;
+
+import com.kernel360.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum JwtErrorCode implements ErrorCode {
+    FAILED_MALFORMED_JWT(HttpStatus.BAD_REQUEST.value(), "EJC001", "유효하지 않은 JWT 문자열 형식입니다."),
+    FAILED_SIGNATURE_JWT(HttpStatus.BAD_REQUEST.value(), "EJC001", "JWT 시그니처가 서버에서 계산한 시그니처와 일치하지 않습니다.");
+    private final int status;
+    private final String code;
+    private final String message;
+
+    JwtErrorCode(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/module-common/src/main/java/com/kernel360/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/com/kernel360/handler/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -60,5 +61,14 @@ public class GlobalExceptionHandler {
         final ErrorResponse response = ErrorResponse.of(CommonErrorCode.NOT_FOUND_RESOURCE);
 
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingHeaderException(final MissingRequestHeaderException e) {
+        log.error("handleMissingHeaderException", e);
+
+        final ErrorResponse response = ErrorResponse.of(CommonErrorCode.INVALID_REQUEST_HEADERS);
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/module-common/src/main/java/com/kernel360/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/com/kernel360/handler/GlobalExceptionHandler.java
@@ -2,8 +2,11 @@ package com.kernel360.handler;
 
 import com.kernel360.code.ErrorCode;
 import com.kernel360.code.common.CommonErrorCode;
+import com.kernel360.code.jwt.JwtErrorCode;
 import com.kernel360.exception.BusinessException;
 import com.kernel360.response.ErrorResponse;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,5 +33,32 @@ public class GlobalExceptionHandler {
         final ErrorResponse response = ErrorResponse.of(CommonErrorCode.INTERNAL_SERVER_ERROR);
 
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    protected ResponseEntity<ErrorResponse> handleMalformedJwtException(final MalformedJwtException e) {
+        log.error("handleMalformedJwtException", e);
+
+        final ErrorResponse response = ErrorResponse.of(JwtErrorCode.FAILED_MALFORMED_JWT);
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SignatureException.class)
+    protected ResponseEntity<ErrorResponse> handleJwtSignatureException(final SignatureException e) {
+        log.error("handleJwtSignatureException", e);
+
+        final ErrorResponse response = ErrorResponse.of(JwtErrorCode.FAILED_SIGNATURE_JWT);
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NullPointerException.class)
+    protected ResponseEntity<ErrorResponse> handleNullPointerException(final NullPointerException e) {
+        log.error("handleNullPointerException", e);
+
+        final ErrorResponse response = ErrorResponse.of(CommonErrorCode.NOT_FOUND_RESOURCE);
+
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`커스텀 예외 메시지 처리를 추가합니다.`

<br>

## 🔨 Modified
> `MalformedJwtException`, `io.jsonwebtoken.security.SignatureException` ,`NullPointerException` , 
 `MissingRequestHeaderException` 에 대한 커스텀 예외 응답 처리를 추가하였습니다.



<br>

## 🌟 More
- _예상할 수 없는 예외를 제외한 모든 예외에 대한 커스텀 예외 처리를 계속 추가하여야 합니다._

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
