### PR TITLE
Feature::즐겨찾기,메인페이지검색 api 추가

### DIFF
--- a/module-admin/src/main/java/com/kernel360/product/service/ProductService.java
+++ b/module-admin/src/main/java/com/kernel360/product/service/ProductService.java
@@ -1,7 +1,7 @@
 package com.kernel360.product.service;
 
 import com.kernel360.exception.BusinessException;
-import com.kernel360.likes.repository.LikeRepository;
+import com.kernel360.likes.repository.LikeRepositoryJpa;
 import com.kernel360.product.code.ProductsErrorCode;
 import com.kernel360.product.dto.ProductDetailDto;
 import com.kernel360.product.dto.ProductDto;
@@ -9,7 +9,7 @@ import com.kernel360.product.dto.ProductUpdateRequest;
 import com.kernel360.product.dto.RecommendProductsDto;
 import com.kernel360.product.entity.Product;
 import com.kernel360.product.entity.SafetyStatus;
-import com.kernel360.product.repository.ProductRepository;
+import com.kernel360.product.repository.ProductRepositoryJpa;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -23,13 +23,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProductService {
 
-    private final ProductRepository productRepository;
-    private final LikeRepository likeRepository;
+    private final ProductRepositoryJpa productRepositoryJpa;
+    private final LikeRepositoryJpa likeRepositoryJpa;
 
     @Transactional(readOnly = true)
     public List<ProductDto> getProducts() {
 
-        return productRepository.findAll()
+        return productRepositoryJpa.findAll()
                 .stream()
                 .map(ProductDto::from)
                 .toList();
@@ -37,7 +37,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public Page<ProductDto> getProductsByKeyword(String keyword, Pageable pageable) {
-        Page<Product> products = productRepository.findByProductNameContaining(keyword, pageable);
+        Page<Product> products = productRepositoryJpa.findByProductNameContaining(keyword, pageable);
 
         return products.map(ProductDto::from);
     }
@@ -45,12 +45,12 @@ public class ProductService {
     @Transactional(readOnly = true)
     public Page<ProductDto> getProductListOrderByViewCount(Pageable pageable) {
 
-        return productRepository.findAllByOrderByViewCountDesc(pageable).map(ProductDto::from);
+        return productRepositoryJpa.findAllByOrderByViewCountDesc(pageable).map(ProductDto::from);
     }
 
     @Transactional(readOnly = true)
     public Page<RecommendProductsDto> getRecommendProducts(Pageable pageable) {
-        Page<Product> productList = productRepository.findTop5ByOrderByProductNameDesc(pageable);
+        Page<Product> productList = productRepositoryJpa.findTop5ByOrderByProductNameDesc(pageable);
 
         return productList.map(RecommendProductsDto::from);
     }
@@ -58,14 +58,14 @@ public class ProductService {
     @Transactional(readOnly = true)
     public Page<ProductDto> getViolationProducts(Pageable pageable) {
 
-        return productRepository.findAllBySafetyStatusEquals(SafetyStatus.DANGER, pageable)
+        return productRepositoryJpa.findAllBySafetyStatusEquals(SafetyStatus.DANGER, pageable)
                 .map(ProductDto::from);
     }
 
     @Transactional(readOnly = true)
     public Page<ProductDto> getRecentProducts(Pageable pageable) {
 
-        return productRepository.findAllByOrderByCreatedAtDesc(pageable)
+        return productRepositoryJpa.findAllByOrderByCreatedAtDesc(pageable)
                 .map(ProductDto::from);
 
     }
@@ -73,31 +73,31 @@ public class ProductService {
     @Transactional(readOnly = true)
     public ProductDetailDto getProductById(Long id) {
 
-        return productRepository.findById(id)
+        return productRepositoryJpa.findById(id)
                 .map(ProductDetailDto::from)
                 .orElseThrow(() -> new BusinessException(ProductsErrorCode.NOT_FOUND_PRODUCT));
     }
 
     @Transactional
     public void updateViewCount(Long id) {
-        productRepository.updateViewCount(id);
+        productRepositoryJpa.updateViewCount(id);
     }
 
     @Transactional(readOnly = true)
     public Page<ProductDetailDto> getProductByOCR(String reportNo, Pageable pageable) {
 
-        return productRepository.findProductByReportNumberEquals(reportNo, pageable)
+        return productRepositoryJpa.findProductByReportNumberEquals(reportNo, pageable)
                 .map(ProductDetailDto::from);
     }
 
     @Transactional(readOnly = true)
     public Page<ProductDto> getFavoriteProducts(Pageable pageable) {
-        Page<Object[]> results = likeRepository.findTop20ByProductNoOrderByLikeCountDesc(pageable);
+        Page<Object[]> results = likeRepositoryJpa.findTop20ByProductNoOrderByLikeCountDesc(pageable);
 
         List<ProductDto> productDtos = results.getContent().stream()
                 .map(result -> {
                     Long productNo = (Long) result[0];
-                    Product product = productRepository.findById(productNo)
+                    Product product = productRepositoryJpa.findById(productNo)
                             .orElseThrow(() -> new BusinessException(ProductsErrorCode.NOT_FOUND_PRODUCT));
                     return ProductDto.from(product);
                 })
@@ -108,7 +108,7 @@ public class ProductService {
 
     @Transactional
     public void updateProduct(ProductUpdateRequest productUpdateRequest) {
-        Product product = productRepository.findById(productUpdateRequest.productNo())
+        Product product = productRepositoryJpa.findById(productUpdateRequest.productNo())
                 .orElseThrow(() -> new BusinessException(ProductsErrorCode.NOT_FOUND_PRODUCT));
 
         product.updateDetail(

--- a/module-api/src/main/java/com/kernel360/likes/controller/LikeController.java
+++ b/module-api/src/main/java/com/kernel360/likes/controller/LikeController.java
@@ -2,9 +2,12 @@ package com.kernel360.likes.controller;
 
 
 import com.kernel360.likes.code.LikeBusinessCode;
+import com.kernel360.likes.dto.LikeSearchDto;
 import com.kernel360.likes.entity.Like;
 import com.kernel360.likes.service.LikeService;
-import com.kernel360.product.dto.ProductDto;
+import com.kernel360.main.controller.Sort;
+import com.kernel360.product.dto.ProductResponse;
+import com.kernel360.product.service.ProductService;
 import com.kernel360.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,11 +23,14 @@ import org.springframework.web.bind.annotation.*;
 public class LikeController {
 
     private final LikeService likeService;
+    private final ProductService productService;
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<Page<ProductDto>>> getAllLikes(
-            @RequestHeader("Authorization") String token, Pageable pageable){
-        Page<ProductDto> likes = likeService.findAllLikes(token, pageable);
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<Page<ProductResponse>>> getAllLikes(
+            @RequestHeader(value = "Authorization", required = true ) String token,
+            @RequestParam(name = "sortType", defaultValue = "viewCnt-order") Sort sortType,
+            @RequestParam(value = "keyword", required = false) String keyword, Pageable pageable){
+        Page<ProductResponse> likes = likeService.findAllLikes(token, LikeSearchDto.of(token, keyword, sortType), pageable);
 
         return ApiResponse.toResponseEntity(LikeBusinessCode.LIKE_LIST_SEARCH_SUCCESS, likes);
     }

--- a/module-api/src/main/java/com/kernel360/likes/dto/LikeSearchDto.java
+++ b/module-api/src/main/java/com/kernel360/likes/dto/LikeSearchDto.java
@@ -1,0 +1,13 @@
+package com.kernel360.likes.dto;
+
+import com.kernel360.main.controller.Sort;
+
+public record LikeSearchDto(
+        String token,
+        String keyword,
+        Sort sortType
+) {
+    public static LikeSearchDto of(String token, String keyword, Sort sortBy) {
+        return new LikeSearchDto(token, keyword, sortBy);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/likes/repository/LikeRepository.java
+++ b/module-api/src/main/java/com/kernel360/likes/repository/LikeRepository.java
@@ -1,0 +1,4 @@
+package com.kernel360.likes.repository;
+
+public interface LikeRepository extends LikeRepositoryJpa, LikeRepositoryDsl{
+}

--- a/module-api/src/main/java/com/kernel360/likes/repository/LikeRepositoryDsl.java
+++ b/module-api/src/main/java/com/kernel360/likes/repository/LikeRepositoryDsl.java
@@ -1,0 +1,10 @@
+package com.kernel360.likes.repository;
+
+import com.kernel360.likes.dto.LikeSearchDto;
+import com.kernel360.product.dto.ProductResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LikeRepositoryDsl {
+    Page<ProductResponse> findAllByCondition(LikeSearchDto condition, Pageable pageable);
+}

--- a/module-api/src/main/java/com/kernel360/likes/repository/LikeRepositoryImpl.java
+++ b/module-api/src/main/java/com/kernel360/likes/repository/LikeRepositoryImpl.java
@@ -27,7 +27,7 @@ import static com.kernel360.likes.entity.QLike.*;
 import static com.kernel360.product.entity.QProduct.product;
 import static org.springframework.util.StringUtils.hasText;
 
-@Repository
+
 @RequiredArgsConstructor
 public class LikeRepositoryImpl implements LikeRepositoryDsl{
 

--- a/module-api/src/main/java/com/kernel360/likes/repository/LikeRepositoryImpl.java
+++ b/module-api/src/main/java/com/kernel360/likes/repository/LikeRepositoryImpl.java
@@ -1,0 +1,107 @@
+package com.kernel360.likes.repository;
+
+import com.kernel360.likes.dto.LikeSearchDto;
+import com.kernel360.likes.entity.QLike;
+import com.kernel360.member.entity.Member;
+import com.kernel360.member.repository.MemberRepository;
+import com.kernel360.product.dto.ProductResponse;
+import com.kernel360.product.dto.QProductResponse;
+import com.kernel360.product.entity.QProduct;
+import com.kernel360.utils.JWT;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.kernel360.likes.entity.QLike.*;
+import static com.kernel360.product.entity.QProduct.product;
+import static org.springframework.util.StringUtils.hasText;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryImpl implements LikeRepositoryDsl{
+
+    private final JPAQueryFactory query;
+    private final MemberRepository memberRepository;
+    @Override
+    public Page<ProductResponse> findAllByCondition(LikeSearchDto condition, Pageable pageable) {
+
+        String memberId = JWT.ownerId(condition.token());
+        Member member = memberRepository.findOneById(memberId);
+
+        List<ProductResponse> products =
+                query.select(new QProductResponse(
+                                product.productNo,
+                                product.productName,
+                                product.companyName,
+                                product.item,
+                                getIsLiked(like, product, member),
+                                like.count()
+                        ))
+                        .from(product)
+                        .leftJoin(like).on(product.productNo.eq(like.productNo))
+                        .where(keywordMatching(condition.keyword()))
+                        .groupBy(product.productNo)
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .orderBy(sort(condition.sortType().toString()))
+                        .fetch();
+
+        long total = query
+                .selectFrom(product)
+                .where(keywordMatching(condition.keyword()))
+                .stream().count();
+
+        return new PageImpl<>(products, pageable, total);
+
+    }
+
+    private static Expression<Boolean> getIsLiked(QLike qLike, QProduct qProduct, Member member) {
+        return ExpressionUtils.as(
+                JPAExpressions
+                        .selectOne()
+                        .from(qLike)
+                        .where(
+                                qLike.productNo.eq(qProduct.productNo)
+                                        .and(qLike.memberNo.eq(member.getMemberNo()))
+                        ).exists(),
+                "isLiked"
+        );
+    }
+
+    private BooleanExpression keywordMatching(String keyword) {
+        return hasText(keyword) ?
+                product.productName.contains(keyword)
+                        .or(product.companyName.contains(keyword)
+                                .or(product.item.contains(keyword)))
+                : null;
+    }
+
+    private static OrderSpecifier<?> sort(String sortType) {
+
+        if ("violation-products".equals(sortType)) {
+            return new OrderSpecifier<>(Order.DESC, product.safetyStatus);
+        }
+
+        if ("recent-order".equals(sortType)) {
+            return product.issuedDate.desc();
+        }
+
+        if ("recommend-order".equals(sortType)) {
+            return like.count().desc();
+        }
+        return product.viewCount.desc();
+
+    }
+
+}

--- a/module-api/src/main/java/com/kernel360/likes/service/LikeService.java
+++ b/module-api/src/main/java/com/kernel360/likes/service/LikeService.java
@@ -4,10 +4,10 @@ import com.kernel360.exception.BusinessException;
 import com.kernel360.likes.code.LikeErrorCode;
 import com.kernel360.likes.dto.LikeSearchDto;
 import com.kernel360.likes.entity.Like;
-import com.kernel360.likes.repository.LikeRepositoryJpa;
+import com.kernel360.likes.repository.LikeRepository;
 import com.kernel360.member.service.MemberService;
 import com.kernel360.product.dto.ProductResponse;
-import com.kernel360.product.repository.ProductRepositoryJpa;
+import com.kernel360.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -23,32 +23,32 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LikeService {
 
-    private final LikeRepositoryJpa likeRepositoryJpa;
+    private final LikeRepository likeRepository;
     private final MemberService memberService;
-    private final ProductRepositoryJpa productRepositoryJpa;
+    private final ProductRepository productRepository;
 
     @Transactional
     public void heartOn(Long productNo, String token) {
         Long memberNo = memberService.findMemberByToken(token).memberNo();
 
-        likeRepositoryJpa.save(Like.of(memberNo, productNo));
+        likeRepository.save(Like.of(memberNo, productNo));
     }
 
     @Transactional
     public void heartOff(Long productNo, String token) {
         Long memberNo = memberService.findMemberByToken(token).memberNo();
-        Like like = likeRepositoryJpa.findByMemberNoAndProductNo(memberNo, productNo)
+        Like like = likeRepository.findByMemberNoAndProductNo(memberNo, productNo)
                                   .orElseThrow(() -> new BusinessException(LikeErrorCode.NO_EXIST_LIKE_INFO));
 
-        likeRepositoryJpa.delete(like);
+        likeRepository.delete(like);
     }
 
     @Transactional(readOnly = true)
     public Page<ProductResponse> findAllLikes(String token, LikeSearchDto likeSearchDto, Pageable pageable) {
         Long memberNo = memberService.findMemberByToken(token).memberNo();
-        Page<Like> likesPage = likeRepositoryJpa.findAllByMemberNo(memberNo, pageable);
+        Page<Like> likesPage = likeRepository.findAllByMemberNo(memberNo, pageable);
         List<ProductResponse> productDtos = likesPage.getContent().stream()
-                .map(like -> productRepositoryJpa.findById(like.getProductNo()))
+                .map(like -> productRepository.findById(like.getProductNo()))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .map(ProductResponse::from)

--- a/module-api/src/main/java/com/kernel360/main/controller/MainController.java
+++ b/module-api/src/main/java/com/kernel360/main/controller/MainController.java
@@ -5,7 +5,7 @@ import com.kernel360.main.dto.BannerDto;
 import com.kernel360.main.dto.RecommendProductsDto;
 import com.kernel360.main.service.MainService;
 import com.kernel360.product.code.ProductsBusinessCode;
-import com.kernel360.product.dto.ProductDto;
+import com.kernel360.product.dto.ProductResponse;
 import com.kernel360.product.service.ProductService;
 import com.kernel360.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -49,9 +49,9 @@ public class MainController {
     }
 
     @GetMapping("/products/rank")
-    ResponseEntity<ApiResponse<Page<ProductDto>>> getProducts(
+    ResponseEntity<ApiResponse<Page<ProductResponse>>> getProducts(
             @RequestParam(name = "sortType", defaultValue = "viewCnt-order") Sort sortType, Pageable pageable) {
-        Page<ProductDto> productDtos = sortType.sort(productService, pageable);
+        Page<ProductResponse> productDtos = sortType.sort(productService, pageable);
 
         return ApiResponse.toResponseEntity(ProductsBusinessCode.GET_PRODUCT_DATA_SUCCESS, productDtos);
     }

--- a/module-api/src/main/java/com/kernel360/main/controller/Sort.java
+++ b/module-api/src/main/java/com/kernel360/main/controller/Sort.java
@@ -1,63 +1,65 @@
 package com.kernel360.main.controller;
 
-import com.kernel360.product.dto.ProductDto;
+import com.kernel360.product.dto.ProductResponse;
+import com.kernel360.product.dto.ProductSearchDto;
 import com.kernel360.product.service.ProductService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
 
 public enum Sort {
 
     VIEW_COUNT_PRODUCT_ORDER("viewCnt-order") {
         @Override
-        Page<ProductDto> sort(ProductService productService, Pageable pageable) {
+        Page<ProductResponse> sort(ProductService productService, Pageable pageable) {
 
             return productService.getProductListOrderByViewCount(pageable);
         }
 
         @Override
-        public Page<ProductDto> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
+        public Page<ProductResponse> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
 
             return productService.getProductWithKeywordAndOrderByViewCount(keyword, pageable);
         }
 
-
     },
+
     VIOLATION_PRODUCT_LIST("violation-products") {
         @Override
-        Page<ProductDto> sort(ProductService productService, Pageable pageable) {
+        Page<ProductResponse> sort(ProductService productService, Pageable pageable) {
 
             return productService.getViolationProducts(pageable);
         }
 
         @Override
-        public Page<ProductDto> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
+        public Page<ProductResponse> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
 
             return productService.getProductWithKeywordAndViolationProducts(keyword, pageable);
         }
     },
+
     RECOMMENDATION_PRODUCT_ORDER("recommend-order") {
         @Override
-        Page<ProductDto> sort(ProductService productService, Pageable pageable) {
+        Page<ProductResponse> sort(ProductService productService, Pageable pageable) {
 
             return productService.getFavoriteProducts(pageable);
         }
 
         @Override
-        public Page<ProductDto> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
+        public Page<ProductResponse> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
 
             return productService.getProductWithKeywordAndOrderByRecommend(keyword, pageable);
         }
     },
+
     RECENT_PRODUCT_ORDER("recent-order") {
         @Override
-        Page<ProductDto> sort(ProductService productService, Pageable pageable) {
+        Page<ProductResponse> sort(ProductService productService, Pageable pageable) {
 
             return productService.getRecentProducts(pageable);
         }
 
         @Override
-        public Page<ProductDto> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
+        public Page<ProductResponse> withKeywordSort(ProductService productService, String keyword, Pageable pageable) {
 
             return productService.getProductWithKeywordAndRecentOrder(keyword, pageable);
         }
@@ -73,6 +75,14 @@ public enum Sort {
         return orderType;
     }
 
-    abstract Page<ProductDto> sort(ProductService productService, Pageable pageable);
-    public abstract Page<ProductDto> withKeywordSort(ProductService productService, String keyword, Pageable pageable);
+    abstract Page<ProductResponse> sort(ProductService productService, Pageable pageable);
+
+    public abstract Page<ProductResponse> withKeywordSort(ProductService productService, String keyword, Pageable pageable);
+
+    public Page<ProductResponse> getProductWithCondition(ProductService productService, ProductSearchDto productSearchDto,
+                                                             Pageable pageable) {
+
+        return productService.searchWithCondition(productSearchDto, pageable);
+    }
 }
+

--- a/module-api/src/main/java/com/kernel360/product/controller/ProductController.java
+++ b/module-api/src/main/java/com/kernel360/product/controller/ProductController.java
@@ -1,14 +1,18 @@
 package com.kernel360.product.controller;
+
 import com.kernel360.main.controller.Sort;
 import com.kernel360.product.code.ProductsBusinessCode;
 import com.kernel360.product.dto.ProductDetailDto;
 import com.kernel360.product.dto.ProductDto;
+import com.kernel360.product.dto.ProductResponse;
+import com.kernel360.product.dto.ProductSearchDto;
 import com.kernel360.product.service.ProductService;
 import com.kernel360.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,19 +25,26 @@ public class ProductController {
     private final ProductService productService;
 
     @GetMapping("/products")
-    ResponseEntity<ApiResponse<List<ProductDto>>> findProductList(){
+    ResponseEntity<ApiResponse<List<ProductDto>>> findProductList() {
         final List<ProductDto> products = productService.getProducts();
 
         return ApiResponse.toResponseEntity(ProductsBusinessCode.GET_PRODUCT_DATA_SUCCESS, products);
     }
+
     @GetMapping("/products/search")
-    ResponseEntity<ApiResponse<Page<ProductDto>>> findProductByKeyword(
+    ResponseEntity<ApiResponse<Page<ProductResponse>>> findProductByKeyword(
+            @RequestHeader(value = "Authorization", required = false) String token,
             @RequestParam(name = "sortType", defaultValue = "viewCnt-order") Sort sortType,
-            @RequestParam("keyword") String keyword, Pageable pageable){
-        Page<ProductDto> productDto = sortType.withKeywordSort(productService, keyword, pageable);
+            @RequestParam(value = "keyword", required = false) String keyword, Pageable pageable) {
+        Page<ProductResponse> productDto =
+                !StringUtils.hasText(token) ? sortType.withKeywordSort(productService, keyword, pageable)
+                        : sortType.getProductWithCondition(productService,
+                                                           ProductSearchDto.of(token, keyword, sortType),
+                                                           pageable);
 
         return ApiResponse.toResponseEntity(ProductsBusinessCode.GET_PRODUCT_DATA_SUCCESS, productDto);
     }
+
     @GetMapping("/product/{productNo}")
     ResponseEntity<ApiResponse<ProductDetailDto>> findProductById(@PathVariable("productNo") Long productNo) {
         ProductDetailDto findProductDetailDto = productService.getProductById(productNo);

--- a/module-api/src/main/java/com/kernel360/product/dto/ProductResponse.java
+++ b/module-api/src/main/java/com/kernel360/product/dto/ProductResponse.java
@@ -1,0 +1,37 @@
+package com.kernel360.product.dto;
+
+import com.kernel360.product.entity.Product;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductResponse {
+    private Long productNo;
+    private String productName;
+    private String companyName;
+    private String item;
+    private boolean isLiked;
+    private Long likeCnt;
+
+    @QueryProjection
+    public ProductResponse(Long productNo, String productName, String companyName, String item, boolean isLiked, Long likeCnt) {
+        this.productNo = productNo;
+        this.productName = productName;
+        this.companyName = companyName;
+        this.item = item;
+        this.isLiked = isLiked;
+        this.likeCnt = likeCnt;
+    }
+    public static ProductResponse from(Product product) {
+        return new ProductResponse(
+                product.getProductNo(),
+                product.getProductName(),
+                product.getCompanyName(),
+                product.getItem(),
+                false,
+                0L
+        );
+    }
+}

--- a/module-api/src/main/java/com/kernel360/product/dto/ProductSearchDto.java
+++ b/module-api/src/main/java/com/kernel360/product/dto/ProductSearchDto.java
@@ -1,0 +1,14 @@
+package com.kernel360.product.dto;
+
+import com.kernel360.main.controller.Sort;
+
+public record ProductSearchDto(
+        String token,
+        String keyword,
+        Sort sortType
+
+) {
+    public static ProductSearchDto of(String token, String keyword, Sort sortBy) {
+        return new ProductSearchDto(token, keyword, sortBy);
+    }
+}

--- a/module-api/src/main/java/com/kernel360/product/repository/ProductRepository.java
+++ b/module-api/src/main/java/com/kernel360/product/repository/ProductRepository.java
@@ -1,0 +1,4 @@
+package com.kernel360.product.repository;
+
+public interface ProductRepository extends ProductRepositoryJpa, ProductRepositoryDsl{
+}

--- a/module-api/src/main/java/com/kernel360/product/repository/ProductRepositoryDsl.java
+++ b/module-api/src/main/java/com/kernel360/product/repository/ProductRepositoryDsl.java
@@ -1,0 +1,11 @@
+package com.kernel360.product.repository;
+
+import com.kernel360.product.dto.ProductResponse;
+import com.kernel360.product.dto.ProductSearchDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductRepositoryDsl {
+    Page<ProductResponse> findAllByCondition(ProductSearchDto condition, Pageable pageable);
+
+}

--- a/module-api/src/main/java/com/kernel360/product/repository/ProductRepositoryImpl.java
+++ b/module-api/src/main/java/com/kernel360/product/repository/ProductRepositoryImpl.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
@@ -24,7 +23,6 @@ import static com.kernel360.likes.entity.QLike.*;
 import static com.kernel360.product.entity.QProduct.*;
 import static org.springframework.util.StringUtils.*;
 
-@Repository
 @RequiredArgsConstructor
 public class ProductRepositoryImpl implements ProductRepositoryDsl {
 

--- a/module-api/src/main/java/com/kernel360/product/repository/ProductRepositoryImpl.java
+++ b/module-api/src/main/java/com/kernel360/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,106 @@
+package com.kernel360.product.repository;
+
+import com.kernel360.likes.entity.QLike;
+import com.kernel360.member.entity.Member;
+import com.kernel360.member.repository.MemberRepository;
+import com.kernel360.product.dto.ProductResponse;
+import com.kernel360.product.dto.ProductSearchDto;
+import com.kernel360.product.dto.QProductResponse;
+import com.kernel360.product.entity.QProduct;
+import com.kernel360.utils.JWT;
+import com.querydsl.core.types.*;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.kernel360.likes.entity.QLike.*;
+import static com.kernel360.product.entity.QProduct.*;
+import static org.springframework.util.StringUtils.*;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryDsl {
+
+    private final JPAQueryFactory query;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Page<ProductResponse> findAllByCondition(ProductSearchDto condition, Pageable pageable) {
+
+        String memberId = JWT.ownerId(condition.token());
+        Member member = memberRepository.findOneById(memberId);
+
+        List<ProductResponse> products =
+                query.select(new QProductResponse(
+                                product.productNo,
+                                product.productName,
+                                product.companyName,
+                                product.item,
+                                getIsLiked(like, product, member),
+                                like.count()
+                        ))
+                        .from(like)
+                        .join(product).on(product.productNo.eq(like.productNo))
+                        .where(keywordMatching(condition.keyword()))
+                        .groupBy(product.productNo)
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .orderBy(sort(condition.sortType().toString()))
+                        .fetch();
+
+        long total = query
+                .selectFrom(product)
+                .where(keywordMatching(condition.keyword()))
+                .stream().count();
+
+        return new PageImpl<>(products, pageable, total);
+    }
+
+
+    private static Expression<Boolean> getIsLiked(QLike qLike, QProduct qProduct, Member member) {
+        return ExpressionUtils.as(
+                JPAExpressions
+                        .selectOne()
+                        .from(qLike)
+                        .where(
+                                qLike.productNo.eq(qProduct.productNo)
+                                        .and(qLike.memberNo.eq(member.getMemberNo()))
+                        ).exists(),
+                "isLiked"
+        );
+    }
+
+    private BooleanExpression keywordMatching(String keyword) {
+        return hasText(keyword) ?
+                product.productName.contains(keyword)
+                        .or(product.companyName.contains(keyword)
+                                .or(product.item.contains(keyword)))
+                : null;
+    }
+
+    private static OrderSpecifier<?> sort(String sortType) {
+
+        if ("violation-products".equals(sortType)) {
+            return new OrderSpecifier<>(Order.DESC, product.safetyStatus);
+        }
+
+        if ("recent-order".equals(sortType)) {
+            return product.issuedDate.desc();
+        }
+
+        if ("recommend-order".equals(sortType)) {
+            return like.count().desc();
+        }
+        return product.viewCount.desc();
+
+    }
+
+
+}

--- a/module-api/src/test/java/com/kernel360/product/service/ProductServiceTest.java
+++ b/module-api/src/test/java/com/kernel360/product/service/ProductServiceTest.java
@@ -1,10 +1,11 @@
 package com.kernel360.product.service;
 
-import com.kernel360.likes.repository.LikeRepository;
+import com.kernel360.likes.repository.LikeRepositoryJpa;
 import com.kernel360.product.dto.ProductDetailDto;
 import com.kernel360.product.dto.ProductDto;
 import com.kernel360.product.entity.Product;
-import com.kernel360.product.repository.ProductRepository;
+import com.kernel360.product.repository.ProductRepositoryDsl;
+import com.kernel360.product.repository.ProductRepositoryJpa;
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.*;
 import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
@@ -25,11 +26,12 @@ import static org.mockito.Mockito.when;
 
 class ProductServiceTest {
     private FixtureMonkey fixtureMonkey;
-    private ProductRepository productRepository;
+    private ProductRepositoryJpa productRepositoryJpa;
+    private ProductRepositoryDsl productRepositoryDsl;
     private ProductService productService;
     private Pageable pageable;
 
-    private LikeRepository likeRepository;
+    private LikeRepositoryJpa likeRepositoryJpa;
     @BeforeEach
     void 테스트준비() {
         fixtureMonkey = FixtureMonkey.builder()
@@ -44,9 +46,9 @@ class ProductServiceTest {
                 .plugin(new JakartaValidationPlugin())
                 .build();
 
-        productRepository = mock(ProductRepository.class);
+        productRepositoryJpa = mock(ProductRepositoryJpa.class);
         pageable = mock(Pageable.class);
-        productService = new ProductService(productRepository, likeRepository);
+        productService = new ProductService(productRepositoryJpa, productRepositoryDsl, likeRepositoryJpa);
     }
 
     @Test
@@ -56,7 +58,7 @@ class ProductServiceTest {
                 .set("productNo", 1L)
                 .sample();
 
-        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+        when(productRepositoryJpa.findById(1L)).thenReturn(Optional.of(product));
         ProductDetailDto foundProduct = productService.getProductById(1L);
 
         //then
@@ -86,7 +88,7 @@ class ProductServiceTest {
         }
         Page<Product> productsPage = new PageImpl<>(productList, pageable, productList.size());
 
-        when(productRepository.getProductsByKeyword(keyword, pageable)).thenReturn(productsPage);
+        when(productRepositoryJpa.getProductsByKeyword(keyword, pageable)).thenReturn(productsPage);
 
         Page<ProductDto> productDtos = productService.getProductsByKeyword(keyword, pageable);
 

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ConcernedProductToProductListItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ConcernedProductToProductListItemProcessor.java
@@ -7,11 +7,13 @@ import com.kernel360.ecolife.repository.ConcernedProductRepository;
 import com.kernel360.modulebatch.product.dto.ProductDto;
 import com.kernel360.product.entity.Product;
 import com.kernel360.product.entity.SafetyStatus;
-import com.kernel360.product.repository.ProductRepository;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import com.kernel360.product.repository.ProductRepositoryJpa;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -26,7 +28,7 @@ public class ConcernedProductToProductListItemProcessor implements ItemProcessor
 
     private final ConcernedProductRepository concernedProductRepository;
 
-    private final ProductRepository productRepository;
+    private final ProductRepositoryJpa productRepositoryJpa;
 
     private final BrandRepository brandRepository;
 
@@ -69,7 +71,7 @@ public class ConcernedProductToProductListItemProcessor implements ItemProcessor
         List<Product> productList = new ArrayList<>();
 
         for (ProductDto productDto : productDtoList) {
-            Optional<Product> foundProduct = productRepository.findProductByProductNameAndCompanyName(
+            Optional<Product> foundProduct = productRepositoryJpa.findProductByProductNameAndCompanyName(
                     productDto.productName(), "%" + getCompanyNameWithoutSlash(productDto.companyName()) + "%");
 
             boolean foundInList = productList.stream().anyMatch(

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ReportedProductToProductItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/ReportedProductToProductItemProcessor.java
@@ -6,10 +6,12 @@ import com.kernel360.ecolife.entity.ReportedProduct;
 import com.kernel360.modulebatch.product.dto.ProductDto;
 import com.kernel360.product.entity.Product;
 import com.kernel360.product.entity.SafetyStatus;
-import com.kernel360.product.repository.ProductRepository;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+
+import com.kernel360.product.repository.ProductRepositoryJpa;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -24,7 +26,7 @@ import org.springframework.stereotype.Component;
 @ComponentScan("com.kernel360.brand")
 @RequiredArgsConstructor
 public class ReportedProductToProductItemProcessor implements ItemProcessor<ReportedProduct, Product> {
-    private final ProductRepository productRepository;
+    private final ProductRepositoryJpa productRepositoryJpa;
 
     private final BrandRepository brandRepository;
 
@@ -56,7 +58,7 @@ public class ReportedProductToProductItemProcessor implements ItemProcessor<Repo
                 rp.getManufacture(), rp.getManufactureMethod(),
                 rp.getManufactureNation(), null);
 
-        Optional<Product> foundProduct = productRepository
+        Optional<Product> foundProduct = productRepositoryJpa
                 .findProductByProductNameAndCompanyName(productDto.productName(),
                         addWildCardToCompanyName(getCompanyNameWithoutSlash(productDto.companyName())));
 

--- a/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/UpdateProductFromViolatedProductItemProcessor.java
+++ b/module-batch/src/main/java/com/kernel360/modulebatch/product/job/infra/UpdateProductFromViolatedProductItemProcessor.java
@@ -2,8 +2,10 @@ package com.kernel360.modulebatch.product.job.infra;
 
 import com.kernel360.modulebatch.product.dto.ProductJoinDto;
 import com.kernel360.product.entity.Product;
-import com.kernel360.product.repository.ProductRepository;
+
 import java.util.Optional;
+
+import com.kernel360.product.repository.ProductRepositoryJpa;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
@@ -14,14 +16,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UpdateProductFromViolatedProductItemProcessor implements ItemProcessor<ProductJoinDto, Product> {
 
-    private final ProductRepository productRepository;
+    private final ProductRepositoryJpa productRepositoryJpa;
 
     @Override
     public Product process(ProductJoinDto item) throws Exception {
         String productName = item.productName();
         String companyName = item.companyName();
 
-        Optional<Product> foundProduct = productRepository.findProductByProductNameAndCompanyName(productName,
+        Optional<Product> foundProduct = productRepositoryJpa.findProductByProductNameAndCompanyName(productName,
                 companyName);
 
         if (foundProduct.isPresent()) {

--- a/module-domain/src/main/java/com/kernel360/likes/repository/LikeRepositoryJpa.java
+++ b/module-domain/src/main/java/com/kernel360/likes/repository/LikeRepositoryJpa.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 
 @Repository
-public interface LikeRepository extends JpaRepository<Like, Long> {
+public interface LikeRepositoryJpa extends JpaRepository<Like, Long> {
     Optional<Like> findByMemberNoAndProductNo(Long memberNo, Long productNo);
 
     Page<Like> findAllByMemberNo(Long memberNo, Pageable pageable);

--- a/module-domain/src/main/java/com/kernel360/likes/repository/LikeRepositoryJpa.java
+++ b/module-domain/src/main/java/com/kernel360/likes/repository/LikeRepositoryJpa.java
@@ -5,12 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 
-@Repository
+
 public interface LikeRepositoryJpa extends JpaRepository<Like, Long> {
     Optional<Like> findByMemberNoAndProductNo(Long memberNo, Long productNo);
 

--- a/module-domain/src/main/java/com/kernel360/product/repository/ProductRepositoryJpa.java
+++ b/module-domain/src/main/java/com/kernel360/product/repository/ProductRepositoryJpa.java
@@ -1,10 +1,6 @@
 package com.kernel360.product.repository;
 
 import com.kernel360.product.entity.Product;
-
-import java.util.List;
-import java.util.Optional;
-
 import com.kernel360.product.entity.SafetyStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,9 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.List;
+import java.util.Optional;
+
 public interface ProductRepositoryJpa extends JpaRepository<Product, Long>  {
 
     Page<Product> findAllByOrderByViewCountDesc(Pageable pageable);

--- a/module-domain/src/main/java/com/kernel360/product/repository/ProductRepositoryJpa.java
+++ b/module-domain/src/main/java/com/kernel360/product/repository/ProductRepositoryJpa.java
@@ -15,7 +15,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepositoryJpa extends JpaRepository<Product, Long>  {
 
     Page<Product> findAllByOrderByViewCountDesc(Pageable pageable);
 


### PR DESCRIPTION
## 💡 Motivation and Context

- 즐겨찾기 : 검색어, 정렬에 따른 api를 추가하였습니다.
- 메인페이지 : 검색어, 정렬에 따른 api를 추가하였습니다.
- 로그인/비로그인에 따라, 좋아요 선택여부와, 제품별 좋아요수를 추가한 정보를 제공합니다.
- 경우의 수가 많아 querydsl을 이용하였습니다.
<img width="554" alt="image" src="https://github.com/Kernel360/F1-WashPedia-BE/assets/91066575/8a4e5adf-3d03-482b-9730-0118aecea934">

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  
  - api 추가
<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #259
