### PR TITLE
fix :: 비밀번호 변경시 기존의 비밀번호를 입력하지 못하도록 유효성 검사하는 조건이 반대로 걸려있던 조건문 수정

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/service/MemberService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/MemberService.java
@@ -136,7 +136,7 @@ public class MemberService {
         String id = JWT.ownerId(token);
         Member member = memberRepository.findOneByIdForAccountTypeByPlatform(id);
 
-        if (!member.getPassword().equals(ConvertSHA256.convertToSHA256(password))) {
+        if (member.getPassword().equals(ConvertSHA256.convertToSHA256(password))) {
             throw new BusinessException(MemberErrorCode.WRONG_PASSWORD_REQUEST);
         }
 


### PR DESCRIPTION
## 💡 Motivation and Context
`비밀번호 변경시 기존의 비밀번호를 입력하지 못하도록 유효성 검사하는 조건이 반대로 걸려있던 조건문 수정`

<br>

## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - _여기에 세부 변경사항을 설명해주세요_

<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
