### PR TITLE
Hotfix : 마이페이지 비밀번호 변경, 비밀번호 재설정 로직 수정

### DIFF
--- a/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
+++ b/module-api/src/main/java/com/kernel360/member/service/FindCredentialService.java
@@ -104,7 +104,7 @@ public class FindCredentialService implements RedisUtils {
         String accessToken = generateUUID();
 
         String uriString = UriComponentsBuilder.fromHttpUrl(FE_HOST_HTTP_URL)
-                                               .path("/change-password")
+                                               .path("/reset-password")
                                                .queryParam("token", accessToken)
                                                .build()
                                                .toUriString();

--- a/module-api/src/main/java/com/kernel360/mypage/controller/MyPageController.java
+++ b/module-api/src/main/java/com/kernel360/mypage/controller/MyPageController.java
@@ -51,8 +51,8 @@ public class MyPageController {
     }
 
     @PostMapping("/change-password")
-    ResponseEntity<ApiResponse<String>> changePassword(@RequestBody String password, @RequestHeader("Authorization") String authToken) {
-        memberService.changePassword(password, authToken);
+    ResponseEntity<ApiResponse<String>> changePassword(@RequestBody PasswordDto passwordDto, @RequestHeader("Authorization") String authToken) {
+        memberService.changePassword(passwordDto.password(), authToken);
 
         return ApiResponse.toResponseEntity(MemberBusinessCode.SUCCESS_VALIDATE_PASSWORD_MEMBER);
     }


### PR DESCRIPTION
## 💡 Motivation and Context
`마이페이지 비밀번호 변경, 비밀번호 재설정 로직 수정`

<br>

## 🔨 Modified
> 마이페이지 비밀번호 변경 시, DTO 가 아닌 String 을 사용하던 문제를 수정합니다
    ![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/46354aea-da46-4004-8029-69824772fea3)

> 비밀번호 재설정 링크가 가리키는 화면 주소를 "reset-password" 로 변경합니다.
    ![image](https://github.com/Kernel360/F1-WashPedia-BE/assets/73059667/76ad4485-8c53-4e57-8f3d-c685171eee25)



<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
